### PR TITLE
修改 FindXxx.cmake 的头文件路径寻找的错误写法

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 # ----------------------------------------------------------------------------
 #  RMVL utilities macro and function
 # ----------------------------------------------------------------------------
-include(RMVLUtils)
+include(cmake/RMVLUtils.cmake)
 
 # Build Type
 if(NOT CMAKE_BUILD_TYPE)
@@ -49,27 +49,27 @@ endif()
 #  Build
 # ----------------------------------------------------------------------------
 # RMVL Install layout 
-include(RMVLInstall)
-include(RMVLModule)
-include(RMVLExtraTarget)
+include(cmake/RMVLInstall.cmake)
+include(cmake/RMVLModule.cmake)
+include(cmake/RMVLExtraTarget.cmake)
 
 include_directories(${CMAKE_BINARY_DIR})
 
 # ----------------------------------------------------------------------------
 #  RMVL compile configure and options
 # ----------------------------------------------------------------------------
-include(RMVLCompilerOptions)
+include(cmake/RMVLCompilerOptions.cmake)
 
 # ----------------------------------------------------------------------------
 #  Get actual RMVL version number from sources
 # ----------------------------------------------------------------------------
-include(RMVLVersion)
+include(cmake/RMVLVersion.cmake)
 
 # ----------------------------------------------------------------------------
 #  RMVL parameters and miscellaneous generation
 # ----------------------------------------------------------------------------
 set(para_template_path "${CMAKE_SOURCE_DIR}/cmake/templates" CACHE STRING "GenPara template path" FORCE)
-include(RMVLGenPara)
+include(cmake/RMVLGenPara.cmake)
 
 # ----------------------------------------------------------------------------
 #  Process subdirectories
@@ -108,9 +108,9 @@ endif()
 # ----------------------------------------------------------------------------
 #  Finalization: generate configuration-based files
 # ----------------------------------------------------------------------------
-include(RMVLGenHeaders)
+include(cmake/RMVLGenHeaders.cmake)
 
-include(RMVLGenConfig)
+include(cmake/RMVLGenConfig.cmake)
 
 # ----------------------------------------------------------------------------
 #  Summary:

--- a/cmake/FindHikSDK.cmake
+++ b/cmake/FindHikSDK.cmake
@@ -5,10 +5,10 @@ if(MVCAM_SDK_PATH STREQUAL "")
 endif()
 
 # add the include directories path
-list(APPEND HikSDK_INCLUDE_DIR "${MVCAM_SDK_PATH}/include")
 find_path(
   HikSDK_INCLUDE_DIR
-  PATH "${HikSDK_INCLUDE_DIR}"
+  NAMES "MvCameraControl.h"
+  PATHS "${MVCAM_SDK_PATH}/include"
   NO_DEFAULT_PATH
 )
 
@@ -16,7 +16,7 @@ find_path(
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "amd64")
   set(ARCH_HIKLIB "64")
 elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86" OR arch STREQUAL "i386")
-  set(arARCH_HIKLIBch "32")
+  set(ARCH_HIKLIB "32")
 elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
   set(ARCH_HIKLIB "arm64")
 elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")

--- a/cmake/FindMvSDK.cmake
+++ b/cmake/FindMvSDK.cmake
@@ -1,23 +1,16 @@
 # add the include directories path
-list(APPEND MvSDK_INCLUDE_DIR "/usr/include")
 find_path(
   MvSDK_INCLUDE_DIR
-  PATH "${MvSDK_INCLUDE_DIR}"
+  NAMES "CameraApi.h"
+  PATHS "/usr/include"
   NO_DEFAULT_PATH
 )
-
-if(EXISTS "${MvSDK_INCLUDE_DIR}/CameraApi.h")
-  set(inc_file_exists ON)
-else()
-  set(inc_file_exists OFF)
-endif()
-
 
 # add libraries
 find_library(
   MvSDK_LIB
-  NAMES "libMVSDK.so"
   PATHS "/lib"
+  NAMES "libMVSDK.so"
   NO_DEFAULT_PATH
 )
 
@@ -30,5 +23,5 @@ include(FindPackageHandleStandardArgs)
 
 find_package_handle_standard_args(
   MvSDK
-  REQUIRED_VARS MvSDK_LIB inc_file_exists
+  REQUIRED_VARS MvSDK_LIB MvSDK_INCLUDE_DIR
 )

--- a/cmake/FindOPTCameraSDK.cmake
+++ b/cmake/FindOPTCameraSDK.cmake
@@ -1,10 +1,10 @@
 set(OPTCameraSDK_root_path "/opt/OPT/OPTCameraDemo")
 
 # add the include directories path
-list(APPEND OPTCameraSDK_INCLUDE_DIR "${OPTCameraSDK_root_path}/include")
 find_path(
   OPTCameraSDK_INCLUDE_DIR
-  PATH "${OPTCameraSDK_INCLUDE_DIR}"
+  NAMES "OPTApi.h"
+  PATHS "${OPTCameraSDK_root_path}/include"
   NO_DEFAULT_PATH
 )
 
@@ -25,5 +25,5 @@ include(FindPackageHandleStandardArgs)
 
 find_package_handle_standard_args(
   OPTCameraSDK
-  REQUIRED_VARS OPTCameraSDK_LIB
+  REQUIRED_VARS OPTCameraSDK_LIB OPTCameraSDK_INCLUDE_DIR
 )

--- a/cmake/FindOPTLightCtrl.cmake
+++ b/cmake/FindOPTLightCtrl.cmake
@@ -1,10 +1,10 @@
 set(OPTLightCtrl_root_path "/opt/OPT/OPTController")
 
 # add the include directories path
-list(APPEND OPTLightCtrl_INCLUDE_DIR "${OPTLightCtrl_root_path}/include")
 find_path(
   OPTLightCtrl_INCLUDE_DIR
-  PATH "${OPTLightCtrl_INCLUDE_DIR}"
+  NAMES "OPTController.h"
+  PATHS "${OPTLightCtrl_root_path}/include"
   NO_DEFAULT_PATH
 )
 
@@ -25,5 +25,5 @@ include(FindPackageHandleStandardArgs)
 
 find_package_handle_standard_args(
   OPTLightCtrl
-  REQUIRED_VARS OPTLightCtrl_LIB
+  REQUIRED_VARS OPTLightCtrl_LIB OPTLightCtrl_INCLUDE_DIR
 )

--- a/cmake/FindOrt.cmake
+++ b/cmake/FindOrt.cmake
@@ -3,10 +3,10 @@ if(NOT ort_root_path)
 endif()
 
 # add the include directories path
-set(Ort_INCLUDE_DIR "${ort_root_path}/include/onnxruntime")
 find_path(
   Ort_INCLUDE_DIR
-  PATH "${Ort_INCLUDE_DIR}"
+  PATHS "${ort_root_path}/include/onnxruntime"
+  NAMES "onnxruntime_cxx_api.h"
   NO_DEFAULT_PATH
 )
 

--- a/doc/tutorials/introduction/linux/install.md
+++ b/doc/tutorials/introduction/linux/install.md
@@ -102,26 +102,26 @@ sudo apt install libeigen3-dev
   <td class="markdownTableBodyCenter">MindVision</td>
   <td class="markdownTableBodyCenter">MvSDK</td>
   <td class="markdownTableBodyCenter">
-    <a href="https://www.mindvision.com.cn/uploadfiles/SDK/linuxSDK_V2.1.0.37.tar.gz">rmvl_mv</a>
+    <a href="https://www.mindvision.com.cn/uploadfiles/SDK/linuxSDK_V2.1.0.37.tar.gz">For all arch</a>
   </td></tr>
 <tr class="markdownTableRowEven">
   <td class="markdownTableBodyCenter">HikVision</td>
   <td class="markdownTableBodyCenter">HikSDK</td>
   <td class="markdownTableBodyCenter">
-    <a href="https://www.hikrobotics.com/cn2/source/support/software/MVS_STD_GML_V2.1.2_221208.zip">rmvl_hik</a>
+    <a href="https://www.hikrobotics.com/cn2/source/support/software/MVS_STD_GML_V2.1.2_221208.zip">For all arch</a>
   </td></tr>
 <tr class="markdownTableRowOdd">
   <td class="markdownTableBodyCenter">OPT</td>
   <td class="markdownTableBodyCenter">OPTCameraSDK</td>
   <td class="markdownTableBodyCenter">
-    <a href="https://vision.scutbot.cn/files/opt_camera_sdk.tar.xz">rmvl_opt_cam</a>
+    <a href="https://vision.scutbot.cn/files/OPTCameraDemo_Ver3.1_Linux_x86_Build20220429.run">For all arch</a>
   </td></tr>
 <tr class="markdownTableRowEven">
   <td class="markdownTableBodyCenter">光源控制器</td>
   <td class="markdownTableBodyCenter">OPT</td>
   <td class="markdownTableBodyCenter">OPTLightCtrl</td>
   <td class="markdownTableBodyCenter">
-    <a href="https://vision.scutbot.cn/files/opt_lc_sdk.tar.xz">rmvl_opt_lc</a>
+    <a href="https://vision.scutbot.cn/files/opt-controller-amd64.deb">For amd64</a>
   </td></tr>
 </table>
 @note 以上与相机相关的 SDK 在进行二次封装得到的库都需要链接到 OpenCV。

--- a/doc/tutorials/modules/devices/camera.md
+++ b/doc/tutorials/modules/devices/camera.md
@@ -151,9 +151,9 @@ rm::OptCamera capture2(rm::CameraConfig::create(rm::HandleMode::Index,
 
 详细的触发方式 @see
 
-- <a href="https://vision.scutbot.cn/HikRobot/index.html" target="_blank"> Hik 工业相机手册 </a>
+- <a href="https://vision.scutbot.cn/HikRobot/index.html" target="_blank"> HIKROBOT 工业相机用户手册</a>
 
-- <a href="https://vision.scutbot.cn/Mv/mv.pdf" target="_blank"> Mv 手册 </a>
+- <a href="https://vision.scutbot.cn/Mv/mv.pdf" target="_blank"> 迈德威视工业相机用户手册</a>
 
 ### 1.2 光学参数设置
 


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-%E6%8F%90%E4%BA%A4%E8%89%AF%E5%A5%BD%E7%9A%84-pr)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 原先 Module 模式的 `FindXxx.cmake` 文件，`find_path` 没有起到原本的作用，现改为
  ```cmake
  find_path(
    xxx
    NAMES "xxx.h"
    PATHS "${xxxx}/include"
    NO_DEFAULT_PATH
  )
  ```

- 修改参数模块在 CMake 解析中输出的信息

