### PR TITLE
修改曲线拟合构建法方程的错误写法

### DIFF
--- a/doc/tutorials/modules/core/least_square.md
+++ b/doc/tutorials/modules/core/least_square.md
@@ -318,22 +318,26 @@ f(t_0)\\f(t_1)\\\vdots\\f(t_{s-1})\end{bmatrix}\tag{3-11}\f]
 不同的 2 个数字向量的内积定义为 \f$(\pmb\alpha,\pmb\beta)=\sum\limits_{i=0}^sa_ib_i\f$，同样的，多项式不同的 2 个分量（例如 \f$\phi_1(t)=t\f$ 和 \f$\phi_2(t)=t^2\f$ 就是不同的分量）之间的内积可以定义为 \f$(\phi_p(t),\phi_q(t))=\sum\limits_{i=0}^{s-1}\phi_p(t_i)\phi_q(t_i)\f$，简记为 \f$(\phi_p,\phi_q)\f$。则有
 
 \f[\left\{\begin{align}
-(\phi_k,\phi_j)&=\sum_{i=0}^{s-1}\phi_k(t_i)\phi_j(t_i)\\
-(\phi_k,f)&=\sum_{i=0}^{s-1}\phi_k(t_i)f(t_i)\equiv d_k\\
+\sum_{i=0}^{s-1}\phi_k(t_i)\phi_j(t_i)&=(\phi_k,\phi_j)\\
+\sum_{i=0}^{s-1}\phi_k(t_i)f(t_i)&=(\phi_k,f)\equiv d_k\\
 \end{align}\right.\tag{4-4}\f]
 
 于是公式 \f$\text{(4-3)}\f$ 可以写成
 
-\f[\sum_{j=0}^{n-1}(\phi_k,\phi_j)=d_k\qquad(k=0,1,\cdots,n-1)\tag{4-5a}\f]
+\f[\sum_{j=0}^{n-1}(\phi_k,\phi_j)a_j=d_k\qquad(k=0,1,\cdots,n-1)\tag{4-5a}\f]
 
 或者展开写为
+
+\f[(\phi_k,\phi_0)a_0+(\phi_k,\phi_1)a_1+\cdots+(\phi_k,\phi_{n-1})a_{n-1}=d_k\qquad(k=0,1,\cdots,n-1)\tag{4-5b}\f]
+
+对每一个 \f$k\f$ 值，可以一并写成如下形式
 
 \f[\left\{\begin{matrix}
 (\phi_0,\phi_0)a_0&+&(\phi_0,\phi_1)a_1&+&\cdots&+&(\phi_0,\phi_{n-1})a_{n-1}&=&d_0\\
 (\phi_1,\phi_0)a_0&+&(\phi_1,\phi_1)a_1&+&\cdots&+&(\phi_1,\phi_{n-1})a_{n-1}&=&d_1\\
 \vdots&&\vdots&&&&\vdots&=&\vdots\\
 (\phi_{n-1},\phi_0)a_0&+&(\phi_{n-1},\phi_1)a_1&+&\cdots&+&(\phi_{n-1},\phi_{n-1})a_{n-1}&=&d_{n-1}\\
-\end{matrix}\right.\tag{4-5b}\f]
+\end{matrix}\right.\tag{4-5c}\f]
 
 上式称为 \f$a_0,a_1,\cdots,a_{n-1}\f$ 的<span style="color: red">法方程（组）</span>，是 \f$n\f$ 阶线性方程组，其系数矩阵是
 
@@ -344,7 +348,7 @@ f(t_0)\\f(t_1)\\\vdots\\f(t_{s-1})\end{bmatrix}\tag{3-11}\f]
 (\phi_{n-1},\phi_0)&(\phi_{n-1},\phi_1)&\cdots&(\phi_{n-1},\phi_{n-1})\\
 \end{bmatrix}\tag{4-6}\f]
 
-对于 \f$(\phi_p,\phi_q)\f$，可以写成矩阵的表示方式，即
+对于 \f$(\phi_p,\phi_q)\f$，依照公式\f$\text{(4-4)}\f$，可以写成矩阵的表示方式，即
 
 \f[\begin{align}(\phi_p,\phi_q)&=\sum_{i=0}^{s-1}\phi_p(t_i)\phi_q(t_i)\\&=[\phi_p(t_0),\phi_p(t_1),\cdots,\phi_p(t_{s-1})]
 \begin{bmatrix}\phi_i(t_0)\\\phi_i(t_1)\\\vdots\\\phi_q(t_{s-1})\end{bmatrix}\end{align}\tag{4-7}\f]
@@ -383,6 +387,8 @@ f(t_0)\\f(t_1)\\\vdots\\f(t_{s-1})\end{bmatrix}\tag{3-11}\f]
 \f[\boxed{\hat{\pmb a}=\left(A^TA\right)^{-1}A^T\pmb f}\tag{4-11}\f]
 
 这与公式 \f$\text{(2-7)}\f$ 完全一致。
+
+此外，对于形如 \f$G\pmb a=\pmb d\ (G=A^TA)\f$ 的方程组，我们在求解的时候可以使用平方根法，即 Cholesky 方法进行求解，OpenCV 中对应的枚举类型为 `cv::DECOMP_CHOLESKY`。
 
 对于<span style="color: green">**示例 3**</span>，可以依次计算出
 

--- a/modules/core/include/rmvl/core/kalman.hpp
+++ b/modules/core/include/rmvl/core/kalman.hpp
@@ -219,12 +219,24 @@ using KF11f = KalmanFilter<float, 1U, 1U>;  //!< 1 × 1 卡尔曼滤波器，无
 using KF11d = KalmanFilter<double, 1U, 1U>; //!< 1 × 1 卡尔曼滤波器，无控制量
 using KF22f = KalmanFilter<float, 2U, 2U>;  //!< 2 × 2 卡尔曼滤波器，无控制量
 using KF22d = KalmanFilter<double, 2U, 2U>; //!< 2 × 2 卡尔曼滤波器，无控制量
+using KF21f = KalmanFilter<float, 2U, 1U>;  //!< 2 × 1 卡尔曼滤波器，无控制量
+using KF21d = KalmanFilter<double, 2U, 1U>; //!< 2 × 1 卡尔曼滤波器，无控制量
 using KF33f = KalmanFilter<float, 3U, 3U>;  //!< 3 × 3 卡尔曼滤波器，无控制量
 using KF33d = KalmanFilter<double, 3U, 3U>; //!< 3 × 3 卡尔曼滤波器，无控制量
+using KF31f = KalmanFilter<float, 3U, 1U>;  //!< 3 × 1 卡尔曼滤波器，无控制量
+using KF31d = KalmanFilter<double, 3U, 1U>; //!< 3 × 1 卡尔曼滤波器，无控制量
+using KF32f = KalmanFilter<float, 3U, 2U>;  //!< 3 × 2 卡尔曼滤波器，无控制量
+using KF32d = KalmanFilter<double, 3U, 2U>; //!< 3 × 2 卡尔曼滤波器，无控制量
 using KF44f = KalmanFilter<float, 4U, 4U>;  //!< 4 × 4 卡尔曼滤波器，无控制量
 using KF44d = KalmanFilter<double, 4U, 4U>; //!< 4 × 4 卡尔曼滤波器，无控制量
+using KF42f = KalmanFilter<float, 4U, 2U>;  //!< 4 × 2 卡尔曼滤波器，无控制量
+using KF42d = KalmanFilter<double, 4U, 2U>; //!< 4 × 2 卡尔曼滤波器，无控制量
 using KF66f = KalmanFilter<float, 6U, 6U>;  //!< 6 × 6 卡尔曼滤波器，无控制量
 using KF66d = KalmanFilter<double, 6U, 6U>; //!< 6 × 6 卡尔曼滤波器，无控制量
+using KF63f = KalmanFilter<float, 6U, 3U>;  //!< 6 × 3 卡尔曼滤波器，无控制量
+using KF63d = KalmanFilter<double, 6U, 3U>; //!< 6 × 3 卡尔曼滤波器，无控制量
+using KF64f = KalmanFilter<float, 6U, 4U>;  //!< 6 × 4 卡尔曼滤波器，无控制量
+using KF64d = KalmanFilter<double, 6U, 4U>; //!< 6 × 4 卡尔曼滤波器，无控制量
 
 //! @} kalman
 

--- a/modules/core/include/rmvl/core/numcal.hpp
+++ b/modules/core/include/rmvl/core/numcal.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <algorithm>
+#include <functional>
 #include <array>
 #include <bitset>
 #include <vector>
@@ -129,7 +130,7 @@ public:
      *
      * @param[in] xs 已知节点的 x 坐标列表 \f$\text{xs}=\{x_0,x_1,\cdots,x_n\}\f$
      * @param[in] ys 已知节点的 y 坐标列表 \f$\text{ys}=\{f(x_0),f(x_1),\cdots,f(x_n)\}\f$
-     * @param[in] order 拟合曲线的阶数，参数从最 **低** 位到最 **高** 位依次为 a0 ~ a7，即
+     * @param[in] order 拟合曲线的阶数，参数从最 **低** 位到最 **高** 位依次为 \f$a_0\f$ ~ \f$a_7\f$，即
      *                  \f[f(x)=a_0+a_1x+\cdots+a_7x^7\tag1\f]例如 `0b01000101` 表示拟合曲线为
      *                  \f[f(x)=a_0+a_2x^2+a_6x^6\tag2\f]
      */

--- a/modules/core/src/numcal.cpp
+++ b/modules/core/src/numcal.cpp
@@ -77,24 +77,28 @@ CurveFitter::CurveFitter(const std::vector<double> &xs, const std::vector<double
             _idx.push_back(i);
     // 构建法方程系数矩阵 G
     cv::Mat G(_idx.size(), _idx.size(), CV_64FC1);
-    std::for_each(_idx.cbegin(), _idx.cend(), [&](std::size_t i) {
-        std::for_each(_idx.cbegin(), _idx.cend(), [&](std::size_t j) {
+    for (size_t i = 0; i < _idx.size(); ++i)
+    {
+        for (size_t j = 0; j < _idx.size(); ++j)
+        {
             G.at<double>(i, j) = 0.0;
-            std::for_each(xs.cbegin(), xs.cend(), [&](std::size_t val) { G.at<double>(i, j) += std::pow(val, i + j); });
-        });
-    });
+            for (size_t k = 0; k < xs.size(); ++k)
+                G.at<double>(i, j) += std::pow(xs[k], _idx[i] + _idx[j]);
+        }
+    }
     // 构建法方程系数矩阵 b
     cv::Mat b(_idx.size(), 1, CV_64FC1);
-    std::for_each(_idx.cbegin(), _idx.cend(), [&](std::size_t i) {
+    for (size_t i = 0; i < _idx.size(); ++i)
+    {
         b.at<double>(i) = 0.0;
-        for (std::size_t k = 0; k < xs.size(); k++)
-            b.at<double>(i) += std::pow(xs[k], i) * ys[k];
-    });
+        for (size_t k = 0; k < xs.size(); ++k)
+            b.at<double>(i) += std::pow(xs[k], _idx[i]) * ys[k];
+    }
     // 求解法方程
     _coeffs.reserve(_idx.size());
     cv::Mat coeffs_mat;
     cv::solve(G, b, coeffs_mat, cv::DECOMP_CHOLESKY);
-    std::for_each(coeffs_mat.begin<double>(), coeffs_mat.end<double>(), [&](double val) { _coeffs.push_back(val); });
+    std::for_each(coeffs_mat.begin<double>(), coeffs_mat.end<double>(), [this](double val) { _coeffs.push_back(val); });
 }
 
 double CurveFitter::operator()(double x) const

--- a/modules/core/test/test_numcal.cpp
+++ b/modules/core/test/test_numcal.cpp
@@ -34,11 +34,27 @@ TEST(NumberCalculation, function_interpolator)
     EXPECT_EQ(foo(4), -7); // a0 = 1, a1=-10/3, a2=3, a3=-2/3
 }
 
-TEST(NumberCalculation, curve_fitter)
+TEST(NumberCalculation, curve_fitter_ax_b)
 {
     rm::CurveFitter foo({1, 2, 3, 4}, {0, 2, 1, 3}, 0b11);
     EXPECT_LE(abs(foo(0.625)), 1e-5);
     EXPECT_LE(foo(0) + 0.5, 1e-5);
+}
+
+TEST(NumberCalculation, curve_fitter_ax2_bx_c)
+{
+    // 2x^2 + 3x - 1
+    rm::CurveFitter foo({0, 1, 2}, {-1, 4, 13}, 0b111);
+    // 2*3^2 + 3*3 - 1 = 26
+    EXPECT_LE(foo(3) - 26, 1e-5);
+}
+
+TEST(NumberCalculation, curve_fitter_ax3_cx_d)
+{
+    // x^3 - 4x + 1
+    rm::CurveFitter foo({0, 1, 2}, {1, -2, 1}, 0b1011);
+    // 3^3 - 4*3 + 1 = 16
+    EXPECT_LE(foo(3) - 16, 1e-5);
 }
 
 TEST(NumberCalculation, nonlinear_solver)


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-%E6%8F%90%E4%BA%A4%E8%89%AF%E5%A5%BD%E7%9A%84-pr)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 原先在构建法方程的写法中，下标与多项式次数混淆，并且缺乏相关的不同次数的单元测试，现予以补全