### PR TITLE
opcua模块服务器支持修改名称，并完善例程

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ include(cmake/RMVLVersion.cmake)
 # ----------------------------------------------------------------------------
 #  RMVL parameters and miscellaneous generation
 # ----------------------------------------------------------------------------
-set(para_template_path "${CMAKE_SOURCE_DIR}/cmake/templates" CACHE STRING "GenPara template path" FORCE)
+set(para_template_path "${CMAKE_SOURCE_DIR}/cmake/templates" CACHE INTERNAL "GenPara template path" FORCE)
 include(cmake/RMVLGenPara.cmake)
 
 # ----------------------------------------------------------------------------

--- a/modules/opcua/include/rmvl/opcua/server.hpp
+++ b/modules/opcua/include/rmvl/opcua/server.hpp
@@ -58,9 +58,10 @@ public:
      * @brief 创建 OPC UA 服务器
      *
      * @param[in] port OPC UA 服务器端口号，一般设置为 `4840U`
+     * @param[in] name OPC UA 服务器名称，为空则采用默认值 `open62541-based OPC UA Application`
      * @param[in] users 用户列表 @see UserConfig
      */
-    explicit Server(uint16_t port, const std::vector<UserConfig> &users = {});
+    Server(uint16_t port, std::string_view name = {}, const std::vector<UserConfig> &users = {});
 
     /**
      * @brief 从服务器配置函数指针创建 OPC UA 服务器
@@ -70,9 +71,10 @@ public:
      *
      * @param[in] on_config 服务器配置函数指针
      * @param[in] port OPC UA 服务器端口号，一般设置为 `4840U`
+     * @param[in] name OPC UA 服务器名称，为空则采用默认值 `open62541-based OPC UA Application`
      * @param[in] users 用户列表 @see UserConfig
      */
-    Server(ServerUserConfig on_config, uint16_t port, const std::vector<UserConfig> &users = {});
+    Server(ServerUserConfig on_config, uint16_t port, std::string_view name = {}, const std::vector<UserConfig> &users = {});
 
     Server(const Server &) = delete;
     Server(Server &&) = delete;

--- a/modules/opcua/param/opcua.para
+++ b/modules/opcua/param/opcua.para
@@ -1,4 +1,4 @@
-uint32_t SPIN_TIMEOUT = 500 # 服务器超时响应的时间，单位 (ms)
+uint32_t SPIN_TIMEOUT = 10 # 服务器超时响应的时间，单位 (ms)
 
 double SAMPLING_INTERVAL = 2      # 服务器监视变量的采样速度，单位 (ms)，不得小于 2ms
 double PUBLISHING_INTERVAL = 2    # 服务器尝试发布数据变更的期望时间间隔，若数据未变更则不会发布，单位 (ms)，不得小于 2ms

--- a/modules/opcua/src/publisher.cpp
+++ b/modules/opcua/src/publisher.cpp
@@ -33,7 +33,7 @@ namespace rm
 /************************************** 发布者 **************************************/
 
 Publisher<TransportID::UDP_UADP>::Publisher(const std::string &pub_name, const std::string &address, uint16_t port,
-                                            const std::vector<UserConfig> &users) : Server(port, users), _name(pub_name)
+                                            const std::vector<UserConfig> &users) : Server(port, pub_name, users), _name(pub_name)
 {
     //////////////////// 添加连接配置 ////////////////////
     UA_ServerConfig_addPubSubTransportLayer(UA_Server_getConfig(_server), UA_PubSubTransportLayerUDPMP());

--- a/modules/opcua/src/subscriber.cpp
+++ b/modules/opcua/src/subscriber.cpp
@@ -30,7 +30,7 @@ namespace rm
 {
 
 Subscriber<TransportID::UDP_UADP>::Subscriber(const std::string &sub_name, const std::string &address, uint16_t port,
-                                              const std::vector<UserConfig> &users) : Server(port, users), _name(sub_name)
+                                              const std::vector<UserConfig> &users) : Server(port, sub_name, users), _name(sub_name)
 {
     //////////////////// 添加连接配置 ////////////////////
     UA_ServerConfig_addPubSubTransportLayer(UA_Server_getConfig(_server), UA_PubSubTransportLayerUDPMP());

--- a/modules/opcua/test/test_opcua_server.cpp
+++ b/modules/opcua/test/test_opcua_server.cpp
@@ -38,7 +38,7 @@ TEST(OPC_UA_Server, value_config)
 // 服务器添加变量节点
 TEST(OPC_UA_Server, add_node)
 {
-    rm::Server svr(4840);
+    rm::Server svr(4840, "TestServer");
     rm::Variable variable = 3.1415;
     variable.browse_name = "test_double";
     variable.description = "this is test double";

--- a/modules/rmath/include/rmvl/rmath/uty_math.hpp
+++ b/modules/rmath/include/rmvl/rmath/uty_math.hpp
@@ -72,6 +72,10 @@ using Matx11f = Matx<float, 1, 1>;
 using Matx11d = Matx<double, 1, 1>;
 using Matx51f = Matx<float, 5, 1>;
 using Matx15f = Matx<float, 1, 5>;
+using Matx51d = Matx<double, 5, 1>;
+using Matx15d = Matx<double, 1, 5>;
+using Matx55f = Matx<float, 5, 5>;
+using Matx55d = Matx<double, 5, 5>;
 
 } // namespace cv
 

--- a/samples/opcua/opcua_client.cpp
+++ b/samples/opcua/opcua_client.cpp
@@ -3,8 +3,8 @@
 int main()
 {
     rm::Client client("opc.tcp://localhost:4840");
-    auto var_id = rm::nodeObjectsFolder | client.find("var_demo");
-    auto var = client.read(var_id);
-    printf("\033[32mValue: %d\033[0m\n", var.cast<int>());
+    auto position_id = rm::nodeObjectsFolder | client.find("position");
+    auto position = client.read(position_id);
+    printf("\033[32mValue: %d\033[0m\n", position.cast<int>());
     return 0;
 }

--- a/samples/opcua/opcua_server.cpp
+++ b/samples/opcua/opcua_server.cpp
@@ -1,18 +1,23 @@
+#include <csignal>
+
 #include "rmvl/opcua/server.hpp"
+
+rm::Server *p_server{nullptr};
+
+inline void onHandle(int) { p_server->stop(); }
 
 int main()
 {
-    rm::Server server(4840U);
-    rm::Variable var = 42;
-    var.display_name = "VarDemo";
-    var.browse_name = "var_demo";
-    server.addVariableNode(var);
-    server.start();
+    signal(SIGINT, onHandle);
 
-    printf("\033[32mServer started for 20 seconds ...\033[0m\n");
-    std::this_thread::sleep_for(std::chrono::seconds(20));
-    printf("\033[32mServer stopped ...\033[0m\n");
-    server.stop();
+    rm::Server server(4840);
+    p_server = &server;
+
+    rm::Variable position = 5500;
+    position.display_name = "Position";
+    position.browse_name = "position";
+    server.addVariableNode(position);
+    server.start();
     server.join();
     return 0;
 }


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-%E6%8F%90%E4%BA%A4%E8%89%AF%E5%A5%BD%E7%9A%84-pr)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- `rm::Server` 构造函数加入带默认参数的服务器名，以支持自定义服务器名称
- 完善例程，取消原先的 `20s` 计时，改为 `SIGINT` 中断结束程序