### PR TITLE
移除 PlanarTracker 距离滤波的队列，使用单观测量

### DIFF
--- a/extra/tracker/include/rmvl/tracker/planar_tracker.h
+++ b/extra/tracker/include/rmvl/tracker/planar_tracker.h
@@ -28,7 +28,6 @@ class PlanarTracker final : public tracker
 private:
     KF21f _distance_filter;             //!< 距离滤波器
     KF42f _motion_filter;               //!< 运动滤波器
-    float _last_distance = 0;           //!< 目标上一帧的距离
     std::deque<float> _relative_speeds; //!< 图像速度的容器
     std::deque<RMStatus> _type_deque;   //!< 状态队列
 

--- a/extra/tracker/src/planar_tracker/filter_update.cpp
+++ b/extra/tracker/src/planar_tracker/filter_update.cpp
@@ -38,16 +38,12 @@ void PlanarTracker::updateDistanceFilter()
     // 设置状态转移矩阵
     _distance_filter.setA({1, 1,
                            0, 1});
-    // 距离差分
     float current_distance = _combo_deque.front()->getExtrinsics().distance();
-    float delta_distance = current_distance - _last_distance;
     // 预测
     _distance_filter.predict();
     // 更新
-    cv::Matx21f correct_vec = _distance_filter.correct({current_distance,
-                                                        delta_distance});
+    cv::Matx21f correct_vec = _distance_filter.correct({current_distance});
     _extrinsic.distance(correct_vec(0));
-    _last_distance = correct_vec(0);
 }
 
 void PlanarTracker::updateMotionFilter()

--- a/extra/types/include/rmvl/types.hpp
+++ b/extra/types/include/rmvl/types.hpp
@@ -13,7 +13,7 @@
 
 #include "rmvl/core/util.hpp"
 
-//! @defgroup types 类型系统
+//! @defgroup types 视觉功能相关的类型系统
 
 namespace rm
 {


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-%E6%8F%90%E4%BA%A4%E8%89%AF%E5%A5%BD%E7%9A%84-pr)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 将 `PlanarTracker` 的 `rm::KF22f` 改为 `rm::KF21f`