### PR TITLE
修复 gyro_compensator 模块中子弹飞行时间错误的 Bug

### DIFF
--- a/extra/compensator/include/rmvl/compensator/compensator.h
+++ b/extra/compensator/include/rmvl/compensator/compensator.h
@@ -45,10 +45,6 @@ struct CompensateInfo
 //! 弹道下坠补偿模块
 class compensator
 {
-protected:
-    float _yaw_static_com;   //!< yaw 轴静态补偿，方向与 yaw 一致
-    float _pitch_static_com; //!< pitch 轴静态补偿，方向与 pitch 一致
-
 public:
     using ptr = std::unique_ptr<compensator>;
 

--- a/extra/compensator/include/rmvl/compensator/gyro_compensator.h
+++ b/extra/compensator/include/rmvl/compensator/gyro_compensator.h
@@ -22,6 +22,9 @@ namespace rm
 //! 整车状态补偿模块
 class GyroCompensator final : public compensator
 {
+    float _yaw_static_com;   //!< yaw 轴静态补偿，方向与 yaw 一致
+    float _pitch_static_com; //!< pitch 轴静态补偿，方向与 pitch 一致
+
 public:
     //! 创建 GyroCompensator 对象
     GyroCompensator();

--- a/extra/compensator/src/gravity_compensator/gravity_impl.h
+++ b/extra/compensator/src/gravity_compensator/gravity_impl.h
@@ -20,12 +20,14 @@ namespace rm
 
 class GravityCompensator::Impl
 {
+    float _yaw_static_com;   //!< yaw 轴静态补偿，方向与 yaw 一致
+    float _pitch_static_com; //!< pitch 轴静态补偿，方向与 pitch 一致
+    
 public:
     Impl();
 
     //! 补偿函数，考虑空气阻力，使用 2 阶龙格库塔方法（中点公式）计算弹道
-    CompensateInfo compensate(const std::vector<group::ptr> &groups, float shoot_speed,
-                              CompensateType com_flag, float &yaw_static_com, float &pitch_static_com);
+    CompensateInfo compensate(const std::vector<group::ptr> &groups, float shoot_speed, CompensateType com_flag);
 
 private:
     /**
@@ -61,7 +63,7 @@ private:
      */
     std::pair<double, double> calc(double x, double y, double velocity);
 
-    std::unique_ptr<RungeKutta2> _rk; //!< 2 阶龙格库塔方法
+    std::unique_ptr<RungeKutta2> _rk; //!< 2 阶龙格库塔求解器
 };
 
 } // namespace rm


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 修复 gyro_compensator 模块中子弹飞行时间错误的 Bug
- 移除 compensator 抽象类中的保护成员
