### PR TITLE
OPC UA 服务器对象析构时会停止并自动阻塞run线程

### DIFF
--- a/3rdparty/open62541/CMakeLists.txt
+++ b/3rdparty/open62541/CMakeLists.txt
@@ -11,6 +11,7 @@ project(
 
 option(UA_ENABLE_PUBSUB "Enable the PubSub protocol" ON)
 rmvl_download(${OPEN62541_PKG} GIT "https://github.com/open62541/open62541.git : v1.3.8")
+set(open62541_VERSION "1.3.8" CACHE INTERNAL "open62541 version")
 
 if(NOT BUILD_SHARED_LIBS)
   install(

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 **机器人控制与视觉库**
 
-| 构建配置 |                         编译器/环境                          |                  Github Actions 工作流状态                   |
-| :------: | :----------------------------------------------------------: | :----------------------------------------------------------: |
-|  CMake   | GCC 7.5.0 x86_64-linux-gnu<br />GCC 9.4.0 x86_64-linux-gnu<br />GCC 12.3.0 x86_64-linux-gnu<br />GCC 14.0.1 x86_64-linux-gnu | [![1.x in Linux](https://github.com/cv-rmvl/rmvl/actions/workflows/linux-1.x.yml/badge.svg)](https://github.com/cv-rmvl/rmvl/actions/workflows/linux-1.x.yml) |
+|                          编译器                          |                 OpenCV                 |           onnxruntime           |               open62541                |                          工作流状态                          |
+| :------------------------------------------------------: | :------------------------------------: | :-----------------------------: | :------------------------------------: | :----------------------------------------------------------: |
+| GCC 7.5.0<br />GCC 9.4.0<br />GCC 12.3.0<br />GCC 14.0.1 | 4.7.0<br />4.7.0<br />4.8.0<br />4.9.0 | 1.12<br />1.10<br />1.12<br />— | 1.3.8<br />1.3.8<br />1.3.8<br />1.4.0 | [![1.x in Linux](https://github.com/cv-rmvl/rmvl/actions/workflows/linux-1.x.yml/badge.svg)](https://github.com/cv-rmvl/rmvl/actions/workflows/linux-1.x.yml) |
 
 RMVL 最初是面向 RoboMaster 赛事的视觉库，现在此之上逐步完善有关基础算法、机器视觉、通信的功能，旨在打造适用范围广、使用简洁、架构统一、功能强大的视觉控制一体库。
 
@@ -12,7 +12,7 @@ RMVL 最初是面向 RoboMaster 赛事的视觉库，现在此之上逐步完善
 
 * 用户手册: <https://cv-rmvl.github.io>
 
-* 问题: <https://github.com/cv-rmvl/rmvl/issues>
+* Issues: <https://github.com/cv-rmvl/rmvl/issues>
 
 * VSCode 扩展插件
 

--- a/modules/opcua/CMakeLists.txt
+++ b/modules/opcua/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(NOT BUILD_OPEN62541 AND WITH_OPEN62541)
-  find_package(open62541 REQUIRED)
-endif()
-
 set(BUILD_rmvl_opcua_INIT ${WITH_OPEN62541})
 # generate parameters module
 rmvl_generate_para(opcua)

--- a/modules/opcua/include/rmvl/opcua/client.hpp
+++ b/modules/opcua/include/rmvl/opcua/client.hpp
@@ -116,14 +116,11 @@ public:
      * @param[out] outputs 输出参数列表
      * @return 是否成功完成当前操作
      */
-    inline bool call(const std::string &name, const std::vector<Variable> &inputs, std::vector<Variable> &outputs)
-    {
-        return call(nodeObjectsFolder, name, inputs, outputs);
-    }
+    inline bool call(const std::string &name, const std::vector<Variable> &inputs, std::vector<Variable> &outputs) { return call(nodeObjectsFolder, name, inputs, outputs); }
 
     /**
      * @brief 添加视图节点 ViewNode 至 `ViewsFolder` 中
-     * 
+     *
      * @param[in] view `rm::View` 表示的视图
      * @return 添加至服务器后，对应视图节点的唯一标识 `NodeId`
      */

--- a/modules/opcua/include/rmvl/opcua/server.hpp
+++ b/modules/opcua/include/rmvl/opcua/server.hpp
@@ -92,8 +92,7 @@ public:
      */
     inline void join() { _run.join(); }
 
-    //! 释放服务器资源
-    inline ~Server() { deleteServer(); }
+    ~Server();
 
     /****************************** 路径搜索 ******************************/
 
@@ -234,10 +233,6 @@ public:
      * @return 是否创建并触发成功？
      */
     bool triggerEvent(const NodeId &node_id, const Event &event);
-
-protected:
-    //! 释放服务器资源
-    void deleteServer();
 };
 
 //! @} opcua

--- a/modules/opcua/src/client.cpp
+++ b/modules/opcua/src/client.cpp
@@ -59,7 +59,7 @@ Client::~Client()
         return;
     auto status = UA_Client_disconnect(_client);
     if (status != UA_STATUSCODE_GOOD)
-        UA_LOG_WARNING(UA_Log_Stdout, UA_LOGCATEGORY_CLIENT, "Failed to disconnect the client");
+        WARNING_("Failed to disconnect the client");
     UA_Client_delete(_client);
     _client = nullptr;
 }
@@ -74,8 +74,7 @@ void Client::spin()
         auto status = UA_Client_run_iterate(_client, para::opcua_param.SPIN_TIMEOUT);
         if (!warning && status != UA_STATUSCODE_GOOD)
         {
-            UA_LOG_WARNING(UA_Log_Stdout, UA_LOGCATEGORY_CLIENT,
-                           "No events and message received, spinning indefinitely, error status: %s", UA_StatusCode_name(status));
+            WARNING_("No events and message received, spinning indefinitely, error status: %s", UA_StatusCode_name(status));
             warning = true;
         }
         warning = (status == UA_STATUSCODE_GOOD) ? false : warning;
@@ -256,10 +255,7 @@ bool Client::monitor(NodeId node, const std::vector<std::string> &names, UA_Clie
         return false;
     }
     else
-    {
-        UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_CLIENT, "Created event monitor, monitor id: %d", monitor_id);
         return true;
-    }
 }
 
 ////////////////////////// Private //////////////////////////

--- a/modules/opcua/src/server.cpp
+++ b/modules/opcua/src/server.cpp
@@ -94,8 +94,11 @@ void Server::start()
     });
 }
 
-void Server::deleteServer()
+Server::~Server()
 {
+    _running = false;
+    if (_run.joinable())
+        _run.join();
     UA_Server_delete(_server);
 }
 
@@ -349,9 +352,7 @@ NodeId Server::addObjectTypeNode(const ObjectType &otype)
             UA_EXPANDEDNODEID_NUMERIC(0, UA_NS0ID_MODELLINGRULE_MANDATORY), true);
         if (status != UA_STATUSCODE_GOOD)
         {
-            UA_LOG_ERROR(
-                UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Failed to add reference during adding object type node, browse name: %s, error code: %s",
-                browse_name.c_str(), UA_StatusCode_name(status));
+            ERROR_("Failed to add reference during adding object type node, browse name: %s, error code: %s", browse_name.c_str(), UA_StatusCode_name(status));
             return UA_NODEID_NULL;
         }
     }
@@ -384,8 +385,7 @@ NodeId Server::addObjectNode(const Object &obj, NodeId parent_id)
     }
     if (type_id.empty())
     {
-        UA_LOG_WARNING(UA_Log_Stdout, UA_LOGCATEGORY_SERVER,
-                       "The object node \"%s\" does not belong to any object type node", obj.browse_name.c_str());
+        WARNING_("The object node \"%s\" does not belong to any object type node", obj.browse_name.c_str());
         type_id = nodeBaseObjectType;
     }
     // 添加至服务器


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 本地单元测试结果

```
[==========] Running 20 tests from 3 test suites.
[----------] Global test environment set-up.
[----------] 5 tests from OPC_UA_ClientTest
[ RUN      ] OPC_UA_ClientTest.read_variable
[       OK ] OPC_UA_ClientTest.read_variable (73 ms)
[ RUN      ] OPC_UA_ClientTest.variable_IO
[       OK ] OPC_UA_ClientTest.variable_IO (72 ms)
[ RUN      ] OPC_UA_ClientTest.call
[       OK ] OPC_UA_ClientTest.call (72 ms)
[ RUN      ] OPC_UA_ClientTest.variable_monitor
[       OK ] OPC_UA_ClientTest.variable_monitor (34 ms)
[ RUN      ] OPC_UA_ClientTest.event_monitor
[2024-06-22 17:32:54.819 (UTC+0800)] info/client        Created event monitor, monitor id: 0
[       OK ] OPC_UA_ClientTest.event_monitor (35 ms)
[----------] 5 tests from OPC_UA_ClientTest (287 ms total)

[----------] 1 test from OPC_UA_PubSub
[ RUN      ] OPC_UA_PubSub.pubsub_config
[2024-06-22 17:32:54.833 (UTC+0800)] info/userland      PubSub channel requested
[2024-06-22 17:32:54.833 (UTC+0800)] info/userland      PubSub channel requested
[       OK ] OPC_UA_PubSub.pubsub_config (151 ms)
[----------] 1 test from OPC_UA_PubSub (151 ms total)

[----------] 14 tests from OPC_UA_Server
[ RUN      ] OPC_UA_Server.variable_config
[       OK ] OPC_UA_Server.variable_config (0 ms)
[ RUN      ] OPC_UA_Server.add_variable_node
[       OK ] OPC_UA_Server.add_variable_node (51 ms)
[ RUN      ] OPC_UA_Server.add_data_source_variable_node
[       OK ] OPC_UA_Server.add_data_source_variable_node (51 ms)
[ RUN      ] OPC_UA_Server.add_variable_type_node
[       OK ] OPC_UA_Server.add_variable_type_node (51 ms)
[ RUN      ] OPC_UA_Server.add_method_node
[       OK ] OPC_UA_Server.add_method_node (51 ms)
[ RUN      ] OPC_UA_Server.add_object_node
[       OK ] OPC_UA_Server.add_object_node (51 ms)
[ RUN      ] OPC_UA_Server.add_object_node_with_method
[       OK ] OPC_UA_Server.add_object_node_with_method (51 ms)
[ RUN      ] OPC_UA_Server.add_object_type_node
[       OK ] OPC_UA_Server.add_object_type_node (52 ms)
[ RUN      ] OPC_UA_Server.create_object_by_object_type
[       OK ] OPC_UA_Server.create_object_by_object_type (51 ms)
[ RUN      ] OPC_UA_Server.find_node
[       OK ] OPC_UA_Server.find_node (51 ms)
[ RUN      ] OPC_UA_Server.add_event_type_node
[       OK ] OPC_UA_Server.add_event_type_node (51 ms)
[ RUN      ] OPC_UA_Server.trigger_event
[       OK ] OPC_UA_Server.trigger_event (52 ms)
[ RUN      ] OPC_UA_Server.function_ptr
[       OK ] OPC_UA_Server.function_ptr (51 ms)
[ RUN      ] OPC_UA_Server.view_node
[       OK ] OPC_UA_Server.view_node (51 ms)
[----------] 14 tests from OPC_UA_Server (669 ms total)

[----------] Global test environment tear-down
[==========] 20 tests from 3 test suites ran. (1109 ms total)
[  PASSED  ] 20 tests.
```