### PR TITLE
修改第三方模块 find_package 在 RMVLConfig,cmake 文件中的使用

### DIFF
--- a/cmake/RMVLGenConfig.cmake
+++ b/cmake/RMVLGenConfig.cmake
@@ -51,15 +51,15 @@ set(RMVL_3RD_PKGS_CONFIGCMAKE "")
 #   exists. otherwise 'find_package' will be added to RMVL_3RD_PKGS_CONFIGCMAKE
 #   
 #  Example:
-#   __find_3rd_package(
-#     tag_detector    # RMVL module name
+#   __find_3rd_package_if(
+#     flag            # whether the package is required, if not, return
 #     TARGET apriltag # the target to be checked, 'FOUND' means
 #                       whether the package has been found
 #     apriltag        # the package name to be found in TARGET mode
 #   )
 # --------------------------------------------------------------------
-function(__find_3rd_package target)
-  if(NOT TARGET rmvl_${target})
+function(__find_3rd_package_if flag)
+  if(NOT ${flag})
     return()
   endif()
   if("${ARGV1}" STREQUAL "TARGET")
@@ -74,9 +74,9 @@ function(__find_3rd_package target)
   set(RMVL_3RD_PKGS_CONFIGCMAKE "${RMVL_3RD_PKGS_CONFIGCMAKE}endif()\n\n" PARENT_SCOPE)
 endfunction()
 
-__find_3rd_package(core FOUND OpenCV)
-__find_3rd_package(tag_detector TARGET apriltag apriltag)
-__find_3rd_package(opcua TARGET open62541::open62541 open62541)
+__find_3rd_package_if(WITH_OPENCV FOUND OpenCV)
+__find_3rd_package_if(WITH_APRILTAG TARGET apriltag apriltag)
+__find_3rd_package_if(WITH_OPEN62541 TARGET open62541::open62541 open62541)
 
 # --------------------------------------------------------------------------------------------
 #  Part 2/3: Generate RMVLConfig.cmake

--- a/modules/opcua/include/rmvl/opcua/client.hpp
+++ b/modules/opcua/include/rmvl/opcua/client.hpp
@@ -32,18 +32,32 @@ class Client
 public:
     /****************************** 通用配置 ******************************/
 
+    //! 创建新的客户端对象
+    Client();
+
     /**
      * @brief 创建新的客户端对象，并建立连接
      *
      * @param[in] address 连接地址，形如 `opc.tcp://127.0.0.1:4840`
      * @param[in] usr 用户信息
      */
-    Client(std::string_view address, UserConfig usr = {});
-
+    Client(std::string_view address, const UserConfig &usr = {});
     ~Client();
 
     Client(const Client &) = delete;
     Client(Client &&) = default;
+
+    Client &operator=(const Client &) = delete;
+    Client &operator=(Client &&) = default;
+
+    /**
+     * @brief 连接到指定的服务器
+     * 
+     * @param[in] address 连接地址，形如 `opc.tcp://127.0.0.1:4840`
+     * @param[in] usr 用户信息
+     * @return 是否连接成功
+     */
+    bool connect(std::string_view address, const UserConfig &usr = {});
 
     /****************************** 路径搜索 ******************************/
 


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 修改第三方模块 find_package 在 RMVLConfig,cmake 文件中的使用，弃用 `TARGET` 作为是否在 RMVLConfig.cmake 文件中启用第三方模块 `find_package` 的依据，转而使用 `option` 变量
- 合并自 `master`，包括 #117 