### PR TITLE
添加 OPC UA 客户端断开连接方法，并在析构中自动断开连接

### DIFF
--- a/modules/opcua/include/rmvl/opcua/client.hpp
+++ b/modules/opcua/include/rmvl/opcua/client.hpp
@@ -52,12 +52,15 @@ public:
 
     /**
      * @brief 连接到指定的服务器
-     * 
+     *
      * @param[in] address 连接地址，形如 `opc.tcp://127.0.0.1:4840`
      * @param[in] usr 用户信息
      * @return 是否连接成功
      */
     bool connect(std::string_view address, const UserConfig &usr = {});
+
+    //! 与服务器断开连接
+    void disconnect();
 
     /****************************** 路径搜索 ******************************/
 

--- a/modules/opcua/src/client.cpp
+++ b/modules/opcua/src/client.cpp
@@ -57,13 +57,11 @@ Client::Client(std::string_view address, const UserConfig &usr) : Client()
 
 Client::~Client()
 {
-    if (_client == nullptr)
-        return;
-    auto status = UA_Client_disconnect(_client);
-    if (status != UA_STATUSCODE_GOOD)
-        WARNING_("Failed to disconnect the client");
-    UA_Client_delete(_client);
-    _client = nullptr;
+    if (_client != nullptr)
+    {
+        disconnect();
+        UA_Client_delete(_client);
+    }
 }
 
 bool Client::connect(std::string_view address, const UserConfig &usr)
@@ -72,6 +70,15 @@ bool Client::connect(std::string_view address, const UserConfig &usr)
         return UA_Client_connect(_client, address.data()) == UA_STATUSCODE_GOOD;
     else
         return UA_Client_connectUsername(_client, address.data(), usr.id.c_str(), usr.passwd.c_str()) == UA_STATUSCODE_GOOD;
+}
+
+void Client::disconnect()
+{
+    if (_client == nullptr)
+        return;
+    auto status = UA_Client_disconnect(_client);
+    if (status != UA_STATUSCODE_GOOD)
+        WARNING_("Failed to disconnect the client");
 }
 
 void Client::spin() const


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 添加 OPC UA 客户端 `rm::Client::disconnect` 方法，并在析构函数中自动调用该方法