### PR TITLE
允许自定义日志输出等级，客户端可自行调整timeout时间

### DIFF
--- a/cmake/templates/para_generator_source.in
+++ b/cmake/templates/para_generator_source.in
@@ -7,6 +7,8 @@
  * 
  */
 
+#include <unordered_map>
+
 #include <opencv2/core/persistence.hpp>
 
 #include "@para_include_path@"

--- a/modules/opcua/include/rmvl/opcua/client.hpp
+++ b/modules/opcua/include/rmvl/opcua/client.hpp
@@ -76,7 +76,7 @@ public:
      * @return 目标节点信息
      * @retval fnic `[_client, browse_name]` 元组
      */
-    inline FindNodeInClient find(const std::string &browse_name, uint16_t ns = 1U) const { return {_client, browse_name, ns}; }
+    inline FindNodeInClient find(std::string_view browse_name, uint16_t ns = 1U) const { return {_client, browse_name, ns}; }
 
     /****************************** 功能配置 ******************************/
 

--- a/modules/opcua/include/rmvl/opcua/server.hpp
+++ b/modules/opcua/include/rmvl/opcua/server.hpp
@@ -76,7 +76,7 @@ public:
      * @return 目标节点信息
      * @retval fnis `[_client, browse_name]` 元组
      */
-    inline FindNodeInServer find(const std::string &browse_name, uint16_t ns = 1U) const { return {_server, browse_name, ns}; }
+    inline FindNodeInServer find(std::string_view browse_name, uint16_t ns = 1U) const { return {_server, browse_name, ns}; }
 
     /**
      * @brief 从指定的变量节点读数据

--- a/modules/opcua/include/rmvl/opcua/utilities.hpp
+++ b/modules/opcua/include/rmvl/opcua/utilities.hpp
@@ -163,9 +163,9 @@ constexpr NodeId nodeHasSubtype(0, UA_NS0ID_HASSUBTYPE);               //!< 引�
 constexpr NodeId nodeHasModellingRule(0, UA_NS0ID_HASMODELLINGRULE);   //!< 引用类型节点：`HasModellingRule` 节点 ID
 
 //! 目标节点信息（服务端指针、浏览名、命名空间索引）
-using FindNodeInServer = ::std::tuple<UA_Server *, ::std::string, uint16_t>;
+using FindNodeInServer = ::std::tuple<UA_Server *, ::std::string_view, uint16_t>;
 //! 目标节点信息（客户端指针、浏览名、命名空间索引）
-using FindNodeInClient = ::std::tuple<UA_Client *, ::std::string, uint16_t>;
+using FindNodeInClient = ::std::tuple<UA_Client *, ::std::string_view, uint16_t>;
 
 /**
  * @brief `UA_TypeFlag` 到对应 `NS0` 下的类型名的映射

--- a/modules/opcua/param/opcua.para
+++ b/modules/opcua/param/opcua.para
@@ -1,4 +1,16 @@
-uint32_t SPIN_TIMEOUT = 10 # 服务器超时响应的时间，单位 (ms)
+enum LogLevel # 服务器/客户端输出日志的最低级别
+  TRACE       # 跟踪级别，输出所有日志
+  DEBUG       # 调试级别，输出调试信息
+  INFO        # 信息级别，输出重要信息
+  WARNING     # 警告级别，输出警告信息
+  ERROR       # 错误级别，输出错误信息
+  FATAL       # 致命级别，输出致命错误信息
+endenum
+
+uint32_t CONNECT_TIMEOUT = 30000           # 请求连接时，判定为超时的时间，单位 (ms)
+LogLevel CLIENT_LOGLEVEL = LogLevel::ERROR # 客户端输出日志的最低级别
+LogLevel SERVER_LOGLEVEL = LogLevel::ERROR # 服务器输出日志的最低级别
+uint32_t SPIN_TIMEOUT = 10                 # 单次 run_iterate 服务器超时响应的时间，单位 (ms)
 
 double SAMPLING_INTERVAL = 2      # 服务器监视变量的采样速度，单位 (ms)，不得小于 2ms
 double PUBLISHING_INTERVAL = 2    # 服务器尝试发布数据变更的期望时间间隔，若数据未变更则不会发布，单位 (ms)，不得小于 2ms

--- a/modules/opcua/src/client.cpp
+++ b/modules/opcua/src/client.cpp
@@ -22,6 +22,15 @@
 namespace rm
 {
 
+static const std::unordered_map<para::LogLevel, UA_LogLevel> loglvl_cli{
+    {para::LogLevel::TRACE, UA_LOGLEVEL_TRACE},
+    {para::LogLevel::DEBUG, UA_LOGLEVEL_DEBUG},
+    {para::LogLevel::INFO, UA_LOGLEVEL_INFO},
+    {para::LogLevel::WARNING, UA_LOGLEVEL_WARNING},
+    {para::LogLevel::ERROR, UA_LOGLEVEL_ERROR},
+    {para::LogLevel::FATAL, UA_LOGLEVEL_FATAL},
+};
+
 ////////////////////////// 通用配置 //////////////////////////
 
 Client::Client()
@@ -29,9 +38,9 @@ Client::Client()
     UA_ClientConfig init_config{};
     // 修改日志
 #if OPCUA_VERSION < 10400
-    init_config.logger = UA_Log_Stdout_withLevel(UA_LOGLEVEL_ERROR);
+    init_config.logger = UA_Log_Stdout_withLevel(loglvl_cli.at(para::opcua_param.CLIENT_LOGLEVEL));
 #else
-    init_config.logging = UA_Log_Stdout_new(UA_LOGLEVEL_ERROR);
+    init_config.logging = UA_Log_Stdout_new(loglvl_cli.at(para::opcua_param.CLIENT_LOGLEVEL));
 #endif
     // 设置默认配置
     auto status = UA_ClientConfig_setDefault(&init_config);
@@ -42,6 +51,10 @@ Client::Client()
         _client = nullptr;
         return;
     }
+
+    // 设置延迟时间
+    init_config.timeout = para::opcua_param.CONNECT_TIMEOUT;
+
     _client = UA_Client_newWithConfig(&init_config);
 }
 

--- a/modules/opcua/src/helper.cpp
+++ b/modules/opcua/src/helper.cpp
@@ -59,7 +59,7 @@ NodeId operator|(NodeId origin, FindNodeInClient &&fnic)
             return response.results[0].targets[0].targetId.nodeId;
 
     ERROR_("Failed to find node, name: %s, error code: %s",
-           browse_name.c_str(), UA_StatusCode_name(response.responseHeader.serviceResult));
+           browse_name.data(), UA_StatusCode_name(response.responseHeader.serviceResult));
     return {};
 }
 

--- a/modules/opcua/src/server.cpp
+++ b/modules/opcua/src/server.cpp
@@ -16,11 +16,21 @@
 #include <open62541/server_config_default.h>
 
 #include "rmvl/opcua/server.hpp"
+#include "rmvlpara/opcua.hpp"
 
 #include "cvt.hpp"
 
 namespace rm
 {
+
+static const std::unordered_map<para::LogLevel, UA_LogLevel> loglvl_srv{
+    {para::LogLevel::TRACE, UA_LOGLEVEL_TRACE},
+    {para::LogLevel::DEBUG, UA_LOGLEVEL_DEBUG},
+    {para::LogLevel::INFO, UA_LOGLEVEL_INFO},
+    {para::LogLevel::WARNING, UA_LOGLEVEL_WARNING},
+    {para::LogLevel::ERROR, UA_LOGLEVEL_ERROR},
+    {para::LogLevel::FATAL, UA_LOGLEVEL_FATAL},
+};
 
 ///////////////////////// 基本配置 /////////////////////////
 
@@ -29,9 +39,9 @@ Server::Server(uint16_t port, std::string_view name, const std::vector<UserConfi
     UA_ServerConfig init_config{};
     // 修改日志
 #if OPCUA_VERSION < 10400
-    init_config.logger = UA_Log_Stdout_withLevel(UA_LOGLEVEL_ERROR);
+    init_config.logger = UA_Log_Stdout_withLevel(loglvl_srv.at(para::opcua_param.SERVER_LOGLEVEL));
 #else
-    init_config.logging = UA_Log_Stdout_new(UA_LOGLEVEL_ERROR);
+    init_config.logging = UA_Log_Stdout_new(loglvl_srv.at(para::opcua_param.SERVER_LOGLEVEL));
 #endif
     // 设置服务器配置
     UA_ServerConfig_setMinimal(&init_config, port, nullptr);


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [ ] 我同意在 Apache 2 开源许可下为本项目做贡献
- [ ] 此 pull request 是在正确的分支上提出的
- [ ] 此 pull request 有对应的错误报告或其他待改进的内容
- [ ] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [ ] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 允许自定义日志输出等级
  - 添加了 `opcua.para` 的自定义宏 `LogLevel`
  - 添加了客户端和服务器的自定义输出等级参数
- 客户端可自行调整服务器连接超时的 `timeout`