### PR TITLE
OPC UA 模块客户端添加移除监视项的功能

### DIFF
--- a/modules/opcua/include/rmvl/opcua/client.hpp
+++ b/modules/opcua/include/rmvl/opcua/client.hpp
@@ -80,7 +80,10 @@ public:
 //! OPC UA 客户端
 class Client
 {
-    UA_Client *_client{nullptr}; //!< 客户端指针
+    //! 客户端指针
+    UA_Client *_client{nullptr};
+    //! 节点号监视项映射表 `[NodeId : [SubId, MonitorId]]`
+    std::unordered_map<UA_UInt32, std::array<UA_UInt32, 2>> _monitor_map;
 
 public:
     /****************************** 通用配置 ******************************/
@@ -208,7 +211,7 @@ public:
      * @param[in] queue_size 通知存放的队列大小，若队列已满，新的通知会覆盖旧的通知，默认为 `10`
      * @return 变量节点监视创建成功？
      */
-    bool monitor(NodeId node, UA_Client_DataChangeNotificationCallback on_change, uint32_t queue_size = 10) const;
+    bool monitor(NodeId node, UA_Client_DataChangeNotificationCallback on_change, uint32_t queue_size = 10);
 
     /**
      * @brief 创建事件监视项，以实现事件的订阅功能
@@ -218,16 +221,15 @@ public:
      * @param[in] on_event 事件回调函数
      * @return 事件监视创建成功？
      */
-    bool monitor(NodeId node, const std::vector<std::string> &names, UA_Client_EventNotificationCallback on_event) const;
+    bool monitor(NodeId node, const std::vector<std::string> &names, UA_Client_EventNotificationCallback on_event);
 
-private:
     /**
-     * @brief 发起订阅请求，并得到订阅 ID
+     * @brief 移除监视项
      *
-     * @param[out] response 订阅请求的响应
-     * @return 是否成功完成当前操作
+     * @param[in] node 待移除监视项的节点号
+     * @return 是否成功移除监视项
      */
-    bool createSubscription(UA_CreateSubscriptionResponse &responce) const;
+    bool remove(NodeId node);
 };
 
 //! @} opcua

--- a/modules/opcua/test/test_opcua_client.cpp
+++ b/modules/opcua/test/test_opcua_client.cpp
@@ -128,6 +128,12 @@ TEST(OPC_UA_ClientTest, variable_monitor)
     client.spinOnce();
     EXPECT_EQ(type_name, "Int32");
     EXPECT_EQ(receive_data, 66);
+    // 移除监视后的数据按预期不会更新
+    client.remove(node_id);
+    client.write(node_id, 123);
+    std::this_thread::sleep_for(10ms);
+    client.spinOnce();
+    EXPECT_EQ(receive_data, 66);
     srv.stop();
     srv.join();
 }


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- OPC UA 模块客户端添加移除监视项的功能 `Client::remove` 方法

### 单元测试

- 添加移除监视后的数据按预期不会更新的测试

### 本地测试结果

```
[ RUN      ] OPC_UA_ClientTest.variable_monitor
[       OK ] OPC_UA_ClientTest.variable_monitor (82 ms)
```

