### PR TITLE
移除 types 的位域，使得多语言标准下均能保证有相同的 ABI

### DIFF
--- a/extra/types/include/rmvl/types.hpp
+++ b/extra/types/include/rmvl/types.hpp
@@ -106,19 +106,11 @@ enum class CompensateType : uint8_t
 //! 状态类型
 struct RMStatus
 {
-#if __cplusplus < 202002L
     ArmorSizeType ArmorSizeTypeID{};   //!< 装甲板大小类型
     RuneType RuneTypeID{};             //!< 能量机关激活类型
     CompensateType CompensateTypeID{}; //!< 强制补偿类型
     RobotType RobotTypeID{};           //!< 机器人类型
     TagType TagTypeID{};               //!< AprilTag 视觉标签类型
-#else
-    ArmorSizeType ArmorSizeTypeID : 2 {};   //!< 装甲板大小类型
-    RuneType RuneTypeID : 2 {};             //!< 能量机关激活类型
-    CompensateType CompensateTypeID : 4 {}; //!< 强制补偿类型
-    RobotType RobotTypeID : 4 {};           //!< 机器人类型
-    TagType TagTypeID{};                    //!< AprilTag 视觉标签类型
-#endif
 
     /**
      * @brief 将类型转化为 `std::string` 类型


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

`rm::RMStatus` 类型移除 C++20 标准下位域初始化的写法，统一移除位域，改为使用简单的组合，即

```cpp
//! 状态类型
struct RMStatus
{
    ArmorSizeType ArmorSizeTypeID{};
    RuneType RuneTypeID{};
    CompensateType CompensateTypeID{};
    RobotType RobotTypeID{};
    TagType TagTypeID{};

    /* code */
};
```

### 解决过程

此问题出现在测试[通过 gcc 和 CMake 使用 RMVL](https://cv-rmvl.github.io/docs/master/da/d80/tutorial_use.html)文档的过程中，图像中并未显示出绘制过的线条，在经过控制台标准输出之后，发现需要绘制的 4 个角点均为 `(0, 0)` 或其他乱码：

```cpp
const auto &corners = p_combo->getCorners();
printf("combo: (%f, %f), (%f, %f), (%f, %f), (%f, %f)\n",
       corners[0].x, corners[0].y,
       corners[1].x, corners[1].y,
       corners[2].x, corners[2].y,
       corners[3].x, corners[3].y);
// 结果如下
// combo: (0.000000, 0.000000), (0.000000, 0.000000), (0.000000, 0.000000), (0.000000, 0.000000)
```

最后发现是 `rm::RMStatus` 的问题


