### PR TITLE
统一 rmvl_add_module 和 rmvl_add_test 添加第三方依赖的标志 EXTERNAL

### DIFF
--- a/cmake/RMVLModule.cmake
+++ b/cmake/RMVLModule.cmake
@@ -215,12 +215,12 @@ endmacro(rmvl_compile_options _target)
 #   此命令用于为指定模块添加新的 RMVL 测试
 #   用法:
 #   rmvl_add_test(<name> <Unit|Performance> <DEPENDS> [rmvl_target...]
-#     <DEPEND_TESTS> [test_target...])
+#     <EXTERNAL> [test_target...])
 #   示例:
 #   rmvl_add_test(
-#     detector Unit                  # 测试名
-#     DEPENDS armor_detector         # 需要依赖的 RMVL 目标库
-#     DEPEND_TESTS GTest::gtest_main # 需要依赖的第三方测试工具目标库
+#     detector Unit              # 测试名
+#     DEPENDS armor_detector     # 需要依赖的 RMVL 目标库
+#     EXTERNAL GTest::gtest_main # 需要依赖的第三方目标库，一般是测试工具库
 #   )
 # ----------------------------------------------------------------------------
 function(rmvl_add_test test_name test_kind)
@@ -228,7 +228,7 @@ function(rmvl_add_test test_name test_kind)
     return()
   endif()
   # Add arguments variable
-  set(multi_args DEPENDS DEPEND_TESTS)
+  set(multi_args DEPENDS EXTERNAL)
   if(NOT "${test_kind}" MATCHES "^(Unit|Performance)$")
     message(FATAL_ERROR "Unknown test kind : ${test_kind}")
   endif()
@@ -273,7 +273,7 @@ function(rmvl_add_test test_name test_kind)
   # Test depends
   target_link_libraries(
     ${the_target}
-    PRIVATE ${TS_DEPEND_TESTS}
+    PRIVATE ${TS_EXTERNAL}
   )
 
   # Add test

--- a/extra/combo/CMakeLists.txt
+++ b/extra/combo/CMakeLists.txt
@@ -35,7 +35,7 @@ if(BUILD_TESTS)
   rmvl_add_test(
     combo Unit
     DEPENDS armor rune
-    DEPEND_TESTS GTest::gtest_main
+    EXTERNAL GTest::gtest_main
   )
 endif(BUILD_TESTS)
 

--- a/extra/compensator/CMakeLists.txt
+++ b/extra/compensator/CMakeLists.txt
@@ -35,7 +35,7 @@ if(BUILD_TESTS)
   rmvl_add_test(
     compensator Unit
     DEPENDS gravity_compensator
-    DEPEND_TESTS GTest::gtest_main
+    EXTERNAL GTest::gtest_main
   )
 endif()
 

--- a/extra/detector/CMakeLists.txt
+++ b/extra/detector/CMakeLists.txt
@@ -60,7 +60,7 @@ if(BUILD_TESTS)
   rmvl_add_test(
     detector Unit
     DEPENDS armor_detector rune_detector gyro_detector
-    DEPEND_TESTS GTest::gtest_main
+    EXTERNAL GTest::gtest_main
   )
 endif(BUILD_TESTS)
 

--- a/extra/feature/CMakeLists.txt
+++ b/extra/feature/CMakeLists.txt
@@ -62,7 +62,7 @@ if(BUILD_TESTS)
   rmvl_add_test(
     feature Unit
     DEPENDS light_blob pilot rune_center rune_target
-    DEPEND_TESTS GTest::gtest_main
+    EXTERNAL GTest::gtest_main
   )
 endif(BUILD_TESTS)
 

--- a/extra/group/CMakeLists.txt
+++ b/extra/group/CMakeLists.txt
@@ -35,7 +35,7 @@ if(BUILD_TESTS)
   rmvl_add_test(
     group Unit
     DEPENDS gyro_group gyro_tracker
-    DEPEND_TESTS GTest::gtest_main
+    EXTERNAL GTest::gtest_main
   )
 endif(BUILD_TESTS)
 

--- a/extra/predictor/CMakeLists.txt
+++ b/extra/predictor/CMakeLists.txt
@@ -55,7 +55,7 @@ if(BUILD_TESTS)
   rmvl_add_test(
     predictor Unit
     DEPENDS spi_rune_predictor
-    DEPEND_TESTS GTest::gtest_main
+    EXTERNAL GTest::gtest_main
   )
 endif(BUILD_TESTS)
 

--- a/extra/tracker/CMakeLists.txt
+++ b/extra/tracker/CMakeLists.txt
@@ -45,7 +45,7 @@ if(BUILD_TESTS)
   rmvl_add_test(
     tracker Unit
     DEPENDS planar_tracker rune_tracker gyro_tracker
-    DEPEND_TESTS GTest::gtest_main
+    EXTERNAL GTest::gtest_main
   )
 endif(BUILD_TESTS)
 

--- a/extra/types/CMakeLists.txt
+++ b/extra/types/CMakeLists.txt
@@ -13,6 +13,6 @@ if(BUILD_TESTS)
   rmvl_add_test(
     types Unit
     DEPENDS types
-    DEPEND_TESTS GTest::gtest_main
+    EXTERNAL GTest::gtest_main
   )
 endif()

--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -31,7 +31,7 @@ if(BUILD_TESTS)
   rmvl_add_test(
     core Unit
     DEPENDS core
-    DEPEND_TESTS GTest::gtest_main
+    EXTERNAL GTest::gtest_main
   )
 endif(BUILD_TESTS)
 
@@ -39,6 +39,6 @@ if(BUILD_PERF_TESTS)
   rmvl_add_test(
     core Performance
     DEPENDS core
-    DEPEND_TESTS benchmark::benchmark_main opencv_video
+    EXTERNAL benchmark::benchmark_main opencv_video
   )
 endif(BUILD_PERF_TESTS)

--- a/modules/opcua/CMakeLists.txt
+++ b/modules/opcua/CMakeLists.txt
@@ -13,7 +13,7 @@ if(BUILD_TESTS AND WITH_OPEN62541)
   rmvl_add_test(
     opcua Unit
     DEPENDS opcua
-    DEPEND_TESTS GTest::gtest_main
+    EXTERNAL GTest::gtest_main
   )
 endif()
 


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 将原先 `rmvl_add_test` 依赖第三方库的标志 `DEPEND_TESTS` 改为 `EXTERNAL` 与 `rmvl_add_module` 统一