### PR TITLE
🐞 修复在不构建文档时，Python Bindings 出错的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 |  分支  |                  编译器                   |           OpenCV            |          onnxruntime           |          open62541          |                          工作流状态                          |
 | :----: | :---------------------------------------: | :-------------------------: | :----------------------------: | :-------------------------: | :----------------------------------------------------------: |
-| master | GCC 7.5.0<br />GCC 12.3.0<br />GCC 14.0.1 | 4.2.0<br />4.8.0<br />4.9.0 | 1.10.0<br />1.12.0<br />1.18.1 | 1.3.8<br />1.3.8<br />1.4.0 | [![1.x in Linux](https://github.com/cv-rmvl/rmvl/actions/workflows/linux-1.x.yml/badge.svg)](https://github.com/cv-rmvl/rmvl/actions/workflows/linux-1.x.yml) |
-|  2.x   | GCC 7.5.0<br />GCC 12.3.0<br />GCC 14.0.1 | 4.2.0<br />4.8.0<br />4.9.0 | 1.10.0<br />1.12.0<br />1.18.1 | 1.3.8<br />1.3.8<br />1.4.0 | [![2.x in Linux](https://github.com/cv-rmvl/rmvl/actions/workflows/linux-2.x.yml/badge.svg)](https://github.com/cv-rmvl/rmvl/actions/workflows/linux-2.x.yml) |
+| master | GCC 7.5.0<br />GCC 12.3.0<br />GCC 14.0.1 | 4.2.0<br />4.5.3<br />4.9.0 | 1.10.0<br />1.12.0<br />1.18.1 | 1.3.8<br />1.3.8<br />1.4.0 | [![1.x in Linux](https://github.com/cv-rmvl/rmvl/actions/workflows/linux-1.x.yml/badge.svg)](https://github.com/cv-rmvl/rmvl/actions/workflows/linux-1.x.yml) |
+|  2.x   | GCC 7.5.0<br />GCC 12.3.0<br />GCC 14.0.1 | 4.2.0<br />4.5.3<br />4.9.0 | 1.10.0<br />1.12.0<br />1.18.1 | 1.3.8<br />1.3.8<br />1.4.0 | [![2.x in Linux](https://github.com/cv-rmvl/rmvl/actions/workflows/linux-2.x.yml/badge.svg)](https://github.com/cv-rmvl/rmvl/actions/workflows/linux-2.x.yml) |
 
 RMVL 最初是面向 RoboMaster 赛事的视觉库，现在此之上逐步完善有关基础算法、机器视觉、通信的功能，旨在打造适用范围广、使用简洁、架构统一、功能强大的视觉控制一体库。
 

--- a/cmake/RMVLGenPython.cmake
+++ b/cmake/RMVLGenPython.cmake
@@ -34,20 +34,19 @@ endfunction()
 #   根据给定目标生成 Python 绑定代码与接口文件
 #   用法:
 #     rmvl_generate_python(
-#       <name>                   # 目标名称，将生成 rmvl_light_py 模块
-#       [FILES <files>]          # 参与绑定的 include/rmvl/ 文件夹下的头文件
-#       [PARA_FILES <files>]     # 参与绑定的 include/rmvlpara/ 文件夹下的头文件
-#       [DEPENDS <dependencies>] # 依赖的模块
+#       <name>                        # 目标名称，将生成 rmvl_light_py 模块
+#       [FILES <file1> [<file2> ...]] # 参与绑定的 include/rmvl/ 文件夹下的头文件
+#       [DEPENDS <dep1> [<dep2> ...]] # 依赖的模块
 #     )
 #   示例:
 #     rmvl_generate_python(core
-#       FILES dataio.hpp timer.hpp
-#       PARA_FILES dataio.hpp
+#       FILES core/dataio.hpp core/timer.hpp
 #       DEPENDS core
 #     )
 # ----------------------------------------------------------------------------
 function(rmvl_generate_python _name)
-  cmake_parse_arguments("PY" "" "" "DEPENDS;FILES" ${ARGN})
+  set(options "DEPENDS" "FILES")
+  cmake_parse_arguments("PY" "" "" "${options}" ${ARGN})
 
   set(pybind_ws "${PROJECT_SOURCE_DIR}/cmake/templates/python")
   set(pybind_inc "${CMAKE_CURRENT_SOURCE_DIR}/include/rmvl")
@@ -58,13 +57,10 @@ function(rmvl_generate_python _name)
   if(NOT PY_FILES)
     return()
   else()
-  foreach(file ${PY_FILES})
-    list(APPEND pybind_headers "${pybind_inc}/${file}")
-  endforeach()
+    foreach(file ${PY_FILES})
+      list(APPEND pybind_headers "${pybind_inc}/${file}")
+    endforeach()
   endif()
-  foreach(file ${PY_PARA_FILES})
-    list(APPEND pybind_headers "${pybind_parainc}/${file}")
-  endforeach()
   set(RMVL_PYBIND_NS "using namespace rm;")
   set(RMVL_PYBIND_INC "#include <rmvl/${_name}.hpp>")
 
@@ -102,9 +98,11 @@ function(rmvl_generate_python _name)
   )
   
   # generate python interface file
-  _pygen("${pybind_headers}" "pyi" RMVL_PYI_CONTENTS
-    DOC_PATH ${RMVL_PYDOC_OUTPUT_DIR}
-  )
+  if(BUILD_DOCS)
+    _pygen("${pybind_headers}" "pyi" RMVL_PYI_CONTENTS DOC_PATH ${RMVL_PYDOC_OUTPUT_DIR})
+  else()
+    _pygen("${pybind_headers}" "pyi" RMVL_PYI_CONTENTS)
+  endif()
   configure_file(
     ${pybind_ws}/rmvl_pyi.pyi.in
     ${RMVL_PYTHON_OUTPUT_DIR}/${RMVL_PYBIND_NAME}.pyi


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 原先生成 Python Bindings 的时候，会自动从文档的 `cfg` 文件中读取内容

  ```python
  with open(f"{doc_path}/pyrmvl_cst.cfg", "a") as file:
      ...
  ```

  但实际上如果没开启 `BUILD_DOCS` 就无法读入该文件，现在 CMake 对 `BUILD_DOCS` 进行了判断