### PR TITLE
🐞 修复在缺少依赖时，仍然生成这部分 rmvlpara 的 Python 绑定的问题

### DIFF
--- a/cmake/RMVLGenPython.cmake
+++ b/cmake/RMVLGenPython.cmake
@@ -35,7 +35,7 @@ endfunction()
 #   用法:
 #     rmvl_generate_python(
 #       <name>                        # 目标名称，将生成 rmvl_light_py 模块
-#       [FILES <file1> [<file2> ...]] # 参与绑定的 include/rmvl/ 文件夹下的头文件
+#       [FILES <file1> [<file2> ...]] # 参与绑定的 include/ 文件夹下的头文件
 #       [DEPENDS <dep1> [<dep2> ...]] # 依赖的模块
 #     )
 #   示例:
@@ -49,10 +49,9 @@ function(rmvl_generate_python _name)
   cmake_parse_arguments("PY" "" "" "${options}" ${ARGN})
 
   set(pybind_ws "${PROJECT_SOURCE_DIR}/cmake/templates/python")
-  set(pybind_inc "${CMAKE_CURRENT_SOURCE_DIR}/include/rmvl")
-  set(pybind_parainc "${CMAKE_CURRENT_SOURCE_DIR}/include/rmvlpara")
+  set(pybind_inc "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
-  # obtain the header files (rmvl)
+  # obtain the header files
   unset(pybind_headers)
   if(NOT PY_FILES)
     return()
@@ -62,21 +61,11 @@ function(rmvl_generate_python _name)
     endforeach()
   endif()
   set(RMVL_PYBIND_NS "using namespace rm;")
-  set(RMVL_PYBIND_INC "#include <rmvl/${_name}.hpp>")
-
-  # obtain the header files (rmvlpara)
-  if(IS_DIRECTORY ${pybind_parainc}/${_name})
-    file(GLOB pybind_para_headers ${pybind_parainc}/${_name}/*.h*)
-  else()
-    if(EXISTS ${pybind_parainc}/${_name}.hpp)
-      set(pybind_para_headers ${pybind_parainc}/${_name}.hpp)
-    endif()
-  endif()
-  if(pybind_para_headers)
+  set(RMVL_PYBIND_INC "#include \"rmvl/${_name}.hpp\"")
+  if(EXISTS "${pybind_inc}/rmvlpara/${_name}.hpp")
+    set(RMVL_PYBIND_INC "${RMVL_PYBIND_INC}\n#include \"rmvlpara/${_name}.hpp\"")
     set(RMVL_PYBIND_NS "${RMVL_PYBIND_NS}\nusing namespace rm::para;")
-    set(RMVL_PYBIND_INC "${RMVL_PYBIND_INC}\n#include <rmvlpara/${_name}.hpp>")
   endif()
-  list(APPEND pybind_headers ${pybind_para_headers})
   
   # generate wrapper code for python
   set(RMVL_PYBIND_NAME "rm_${_name}_py")

--- a/modules/algorithm/CMakeLists.txt
+++ b/modules/algorithm/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 # ----------------------------------------------------------------------------
 if(BUILD_PYTHON)
   rmvl_generate_python(algorithm
-    FILES algorithm/numcal.hpp
+    FILES rmvl/algorithm/numcal.hpp
     DEPENDS algorithm
   )
 endif()

--- a/modules/camera/CMakeLists.txt
+++ b/modules/camera/CMakeLists.txt
@@ -65,10 +65,6 @@ rmvl_add_module(
   EXTRA_HEADER ${OPTCameraSDK_INCLUDE_DIRS}
   EXTERNAL ${OPTCameraSDK_LIBS}
 )
-rmvl_compile_options(
-  opt_camera
-  PUBLIC 
-)
 
 rmvl_generate_module_para(camera)
 
@@ -85,12 +81,12 @@ endif(BUILD_TESTS)
 # --------------------------------------------------------------------------
 if(BUILD_PYTHON)
   if(BUILD_rmvl_camera)
-    list(APPEND cam_inc camera/camutils.hpp) 
+    list(APPEND cam_inc rmvl/camera/camutils.hpp) 
     list(APPEND cam_dep camera)
   endif()
   foreach(m mv hik opt)
     if(BUILD_rmvl_${m}_camera)
-      list(APPEND cam_inc camera/${m}_camera.h) 
+      list(APPEND cam_inc rmvl/camera/${m}_camera.h rmvlpara/camera/${m}_camera.h) 
       list(APPEND cam_dep ${m}_camera)
     endif()
   endforeach()

--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -22,8 +22,11 @@ rmvl_compile_definitions(
 #  Build Python bindings
 # ----------------------------------------------------------------------------
 if(BUILD_PYTHON)
+  foreach(m dataio timer version)
+    list(APPEND core_inc rmvl/core/${m}.hpp)
+  endforeach()
   rmvl_generate_python(core
-    FILES core/dataio.hpp core/timer.hpp core/version.hpp
+    FILES ${core_inc}
     DEPENDS core
   )
 endif()

--- a/modules/light/CMakeLists.txt
+++ b/modules/light/CMakeLists.txt
@@ -17,7 +17,7 @@ rmvl_link_libraries(
 if(BUILD_PYTHON)
   foreach(m opt)
     if(BUILD_rmvl_${m}_light_control)
-      list(APPEND light_inc light/${m}_light_control.h)
+      list(APPEND light_inc rmvl/light/${m}_light_control.h)
       list(APPEND light_dep ${m}_light_control)
     endif()
   endforeach()


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 在缺少第三方硬件 SDK 时，RMVL 参数模块的 Python Bindings 会出现未定义标识符的 error，现参数部分头文件的 Python Bindings 生成与否也由用户决定