### PR TITLE
🐞 相机模块 read 方法重新改为传入 cv::OutputArray

### DIFF
--- a/modules/camera/include/rmvl/camera/hik_camera.h
+++ b/modules/camera/include/rmvl/camera/hik_camera.h
@@ -89,7 +89,9 @@ public:
      * @param[out] image 待读入的图像
      * @return 是否读取成功
      */
-    bool read(cv::Mat image);
+    bool read(cv::OutputArray image);
+
+    //! @cond
 
     /**
      * @brief 从相机设备中读取图像
@@ -102,6 +104,8 @@ public:
         bool res = read(img);
         return {res, img};
     }
+
+    //! @endcond
 
     /**
      * @brief 从相机设备中读取图像

--- a/modules/camera/include/rmvl/camera/mv_camera.h
+++ b/modules/camera/include/rmvl/camera/mv_camera.h
@@ -91,7 +91,9 @@ public:
      * @param[out] image 待读入的图像
      * @return 是否读取成功
      */
-    bool read(cv::Mat image);
+    bool read(cv::OutputArray image);
+
+    //! @cond
 
     /**
      * @brief 从相机设备中读取图像
@@ -104,6 +106,8 @@ public:
         bool res = read(img);
         return {res, img};
     }
+
+    //! @endcond
 
     /**
      * @brief 从相机设备中读取图像

--- a/modules/camera/include/rmvl/camera/opt_camera.h
+++ b/modules/camera/include/rmvl/camera/opt_camera.h
@@ -89,7 +89,9 @@ public:
      * @param[out] image 待读入的图像
      * @return 是否读取成功
      */
-    bool read(cv::Mat image);
+    bool read(cv::OutputArray image);
+
+    //! @cond
 
     /**
      * @brief 从相机设备中读取图像
@@ -102,6 +104,8 @@ public:
         bool res = read(img);
         return {res, img};
     }
+
+    //! @endcond
 
     /**
      * @brief 相机重连

--- a/modules/camera/src/hik_camera/hik_camera.cpp
+++ b/modules/camera/src/hik_camera/hik_camera.cpp
@@ -23,7 +23,7 @@ HikCamera::HikCamera(CameraConfig init_mode, std::string_view serial) : _impl(ne
 HikCamera::~HikCamera() { delete _impl; }
 bool HikCamera::set(int propId, double value) { return _impl->set(propId, value); }
 double HikCamera::get(int propId) const { return _impl->get(propId); }
-bool HikCamera::read(cv::Mat image) { return _impl->read(image); }
+bool HikCamera::read(cv::OutputArray image) { return _impl->read(image); }
 bool HikCamera::isOpened() const { return _impl->isOpened(); }
 bool HikCamera::reconnect() { return _impl->reconnect(); }
 

--- a/modules/camera/src/mv_camera/mv_camera.cpp
+++ b/modules/camera/src/mv_camera/mv_camera.cpp
@@ -23,7 +23,7 @@ MvCamera::~MvCamera() { delete _impl; }
 bool MvCamera::set(int propId, double value) { return _impl->set(propId, value); }
 double MvCamera::get(int propId) const { return _impl->get(propId); }
 bool MvCamera::isOpened() const { return _impl->isOpened(); }
-bool MvCamera::read(cv::Mat image) { return _impl->read(image); }
+bool MvCamera::read(cv::OutputArray image) { return _impl->read(image); }
 bool MvCamera::reconnect() { return _impl->reconnect(); }
 
 MvCamera::Impl::Impl(CameraConfig init_mode, std::string_view serial) noexcept

--- a/modules/camera/src/mv_camera/mv_camera_impl.h
+++ b/modules/camera/src/mv_camera/mv_camera_impl.h
@@ -69,7 +69,7 @@ public:
     bool retrieve(cv::OutputArray image) noexcept;
 
     //! 从相机设备中读取图像
-    inline bool read(cv::Mat image) noexcept
+    inline bool read(cv::OutputArray image) noexcept
     {
         if (grab())
             retrieve(image);

--- a/modules/camera/src/opt_camera/opt_camera.cpp
+++ b/modules/camera/src/opt_camera/opt_camera.cpp
@@ -22,7 +22,7 @@ OptCamera::~OptCamera() { delete _impl; }
 bool OptCamera::set(int propId, double value) { return _impl->set(propId, value); }
 double OptCamera::get(int propId) const { return _impl->get(propId); }
 bool OptCamera::isOpened() const { return _impl->isOpened(); }
-bool OptCamera::read(cv::Mat image) { return _impl->read(image); }
+bool OptCamera::read(cv::OutputArray image) { return _impl->read(image); }
 bool OptCamera::reconnect() { return _impl->reconnect(); }
 
 /**


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- camera 模块的 `read` 方法在添加 Python 支持后改成了传入`cv::Mat`，即
  ```cpp
  bool read(cv::Mat image);
  ```
  应该改为传入 `cv::Mat &` 或者 `cv::OutputArray`