### PR TITLE
修复未启用 BUILD_DOCS 时启用 BUILD_PYTHON 导致 CMake 出错的问题

### DIFF
--- a/cmake/templates/python/rmvl_pygen.py
+++ b/cmake/templates/python/rmvl_pygen.py
@@ -2,6 +2,7 @@
 C++ to Python binding code generator
 """
 
+import os
 import re
 import argparse
 from collections import defaultdict
@@ -728,16 +729,20 @@ def generate_pyi(lines: list[str], doc_path: str | None) -> str:
 
     # Generate doc cfg
     if doc_path:
-        with open(f"{doc_path}/pyrmvl_cst.cfg", "a") as file:
-            for enum_name, enum_values in enum_classes:
-                for idx, value in enumerate(enum_values):
-                    file.write(f"rm::{enum_name} {value} {idx}\n")
-            for idx, enum in enumerate(enums):
-                file.write(f"rm {enum} {idx}\n")
-        with open(f"{doc_path}/pyrmvl_fns.cfg", "a") as file:
-            for para_class in para_class_fordoc:
-                file.write(f"rm::para::{para_class} read path [[success_?]]\n")
-                file.write(f"rm::para::{para_class} write path [[success_?]]\n")
+        pyrmvl_cst_path = f"{doc_path}/pyrmvl_cst.cfg"
+        pyrmvl_fns_path = f"{doc_path}/pyrmvl_fns.cfg"
+        if os.path.exists(pyrmvl_cst_path):
+            with open(pyrmvl_cst_path, "a") as file:
+                for enum_name, enum_values in enum_classes:
+                    for idx, value in enumerate(enum_values):
+                        file.write(f"rm::{enum_name} {value} {idx}\n")
+                for idx, enum in enumerate(enums):
+                    file.write(f"rm {enum} {idx}\n")
+        if os.path.exists(pyrmvl_fns_path):
+            with open(pyrmvl_fns_path, "a") as file:
+                for para_class in para_class_fordoc:
+                    file.write(f"rm::para::{para_class} read path [[success_?]]\n")
+                    file.write(f"rm::para::{para_class} write path [[success_?]]\n")
     return "\n".join(pyi_content)
 
 


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 在 `rmvl_pygen.py` 中增加了文档配置的检测，以保证不启用 `BUILD_DOCS` 时启用 `BUILD_PYTHON` 不会出现错误