### PR TITLE
现在未检测到 Pybind 时启用 BUILD_PYTHON 会直接下载

### DIFF
--- a/3rdparty/pybind11/CMakeLists.txt
+++ b/3rdparty/pybind11/CMakeLists.txt
@@ -1,0 +1,13 @@
+# ----------------------------------------------------------------------------
+#   pybind11
+# ----------------------------------------------------------------------------
+
+project(
+  pybind11
+  LANGUAGES C
+)
+
+set(ver "2.13.5")
+
+rmvl_download(pybind11 GIT "https://github.com/pybind/pybind11.git : v${ver}")
+set(pybind11_VERSION "${ver}" CACHE INTERNAL "pybind11 version")

--- a/3rdparty/pybind11/LICENSE
+++ b/3rdparty/pybind11/LICENSE
@@ -1,0 +1,29 @@
+Copyright (c) 2016 Wenzel Jakob <wenzel.jakob@epfl.ch>, All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Please also refer to the file .github/CONTRIBUTING.md, which clarifies licensing of
+external contributions to this project including patches, pull requests, etc.

--- a/3rdparty/readme.txt
+++ b/3rdparty/readme.txt
@@ -21,4 +21,9 @@ open62541           Description     An open-source C implementation of OPC UA
                     CMake options   1. BUILD_OPEN62541 to download and build this module (disabled by
                                        default)
                                     2. WITH_OPEN62541 to enable open62541 support for the opcua module
-                                    
+
+pybind11            Description     Seamless operability between C++11 and Python
+                    License         pybind11 is covered by the BSD 3-Clause License, see pybind11/LICENSE
+                    Homepage        https://pybind11.readthedocs.io
+                    CMake options   1. BUILD_PYBIND11 to download and build this module (enabled by default)
+                                    2. WITH_PYBIND11 to enable pybind11 support for the python module

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,12 +208,14 @@ status("")
 status("  Documents (Doxygen):"     BUILD_DOCS THEN "YES (ver ${DOXYGEN_VERSION})" ELSE NO)
 
 # ============================= Python ==============================
+status("")
+status("  Python 3:"                BUILD_PYTHON THEN YES ELSE NO)
 if(BUILD_PYTHON)
-  status("")
-  status("  Python 3:")
-  status("    Interpreter:"     "${RMVL_PYTHON_EXECUTABLE} (ver ${RMVL_PYTHON_VERSION})")
-  status("    Libraries:"       "${RMVL_PYTHON_LIBRARIES}")
-  status("    install path:"    "${RMVL_PYTHON_INSTALL_SUFFIX}")
+  status("     Python generate:")
+  status("        pybind11:"        "ver ${pybind11_VERSION}")
+  status("     Interpreter:"        "${RMVL_PYTHON_EXECUTABLE} (ver ${RMVL_PYTHON_VERSION})")
+  status("     Libraries:"          "${RMVL_PYTHON_LIBRARIES}")
+  status("     install path:"       "${RMVL_PYTHON_INSTALL_SUFFIX}")
 endif()
 
 # ======================== Test and examples ========================

--- a/cmake/RMVLCompilerOptions.cmake
+++ b/cmake/RMVLCompilerOptions.cmake
@@ -298,32 +298,23 @@ option(BUILD_DOCS "Create build rules for RMVL Documentation" OFF)
 
 option(BUILD_PYTHON "Build python bindings" OFF)
 if(BUILD_PYTHON)
-  find_package(pybind11 QUIET)
   find_package(Python3 COMPONENTS Interpreter Development QUIET)
-  if(NOT pybind11_FOUND OR NOT Python3_FOUND)
+  if(NOT Python3_FOUND)
     unset(BUILD_PYTHON CACHE)
     option(BUILD_PYTHON "Build python bindings" OFF)
-    if(NOT Python3_FOUND)
-      message(WARNING
-        "Python3 not found, python bindings will not be built.\n"
-        "If your OS is Ubuntu / Debian, please use the following command:\n"
-        "  sudo apt install python3-dev\n"
-        "If your OS is Windows, please install python3 in the official website:\n"
-        "  https://www.python.org/downloads/"
-      )
-    endif()
-    if(NOT pybind11_FOUND)
-      message(WARNING
-        "pybind11 not found, python bindings will not be built.\n"
-        "If your OS is Ubuntu / Debian, please install pybind11:\n"
-        "  sudo apt install pybind11-dev\n"
-        "or\n"
-        "  pip install pybind11\n"
-        "If your OS is Windows, please use the following command:\n"
-        "  pip install pybind11"
-      )
-    endif()
+    message(WARNING
+      "Python3 not found, python bindings will not be built.\n"
+      "If your OS is Ubuntu / Debian, please use the following command:\n"
+      "  sudo apt install python3-dev\n"
+      "If your OS is Windows, please install python3 in the official website:\n"
+      "  https://www.python.org/downloads/"
+    )
   else()
+    find_package(pybind11 QUIET)
+    if(NOT pybind11_FOUND)
+      add_subdirectory(${CMAKE_SOURCE_DIR}/3rdparty/pybind11)
+    endif()
+    set(pybind11_VERSION "${pybind11_VERSION}" CACHE INTERNAL "pybind11 version")
     set(RMVL_PYTHON_VERSION_MAJOR "${Python3_VERSION_MAJOR}")
     set(RMVL_PYTHON_VERSION_MINOR "${Python3_VERSION_MINOR}")
     set(RMVL_PYTHON_VERSION "${Python3_VERSION}")


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 在启用 `BUILD_PYTHON` 的时候，如果通过 `find_package` 未找到 pybind11，则自动使用 `rmvl_download` 进行下载
- pybind11 添加至 `3rdparty` 中 