### PR TITLE
✨ OPC UA 模块增加循环定时器

### DIFF
--- a/cmake/RMVLGenPara.cmake
+++ b/cmake/RMVLGenPara.cmake
@@ -139,7 +139,7 @@ function(_parse_assign content_line header_line source_read_line source_write_li
   endif()
   # 获取 Source 部分的返回值
   set(ret_source_read_line "${ret_source_read_line}    node = fs[\"${id_sym}\"];\n")
-  if(type_sym MATCHES "^uint\\w*|size_t")
+  if(type_sym MATCHES "^bool|uint\\w*|size_t")
     set(ret_source_read_line "${ret_source_read_line}    if (!node.isNone())\n    {\n")
     set(ret_source_read_line "${ret_source_read_line}        int tmp{};\n        node >> tmp;\n")
     set(ret_source_read_line "${ret_source_read_line}        ${id_sym} = static_cast<${type_sym_correct}>(tmp);\n    }\n")

--- a/doc/py_tutorials/py_modules/py_core.md
+++ b/doc/py_tutorials/py_modules/py_core.md
@@ -18,6 +18,6 @@
 import rm
 
 # 定时器
-t = rm.timer.now()
+t = rm.Timer.now()
 print("now = {:.6f}".format(t))
 ```

--- a/extra/detector/test/armor_detector_test.cpp
+++ b/extra/detector/test/armor_detector_test.cpp
@@ -27,7 +27,7 @@ TEST_F(ArmorDetectorTest, single_armor_function_test)
     buildArmorImg(center, 5);
     // imshow("src", src);
     // waitKey(0);
-    auto info = p_detector->detect(groups, src, RED, GyroData(), timer.now());
+    auto info = p_detector->detect(groups, src, RED, GyroData(), Timer::now());
     EXPECT_EQ(groups.size(), 1);
 
     if (info.combos.size() == 1)
@@ -43,7 +43,7 @@ TEST_F(ArmorDetectorTest, single_armor_more_blob_disturb)
     // 单装甲板区域内有灯条 ( /\/ )
     buildArmorImg(center, 0);
     buildBlobImg(7, center);
-    auto info = p_detector->detect(groups, src, BLUE, GyroData(), timer.now());
+    auto info = p_detector->detect(groups, src, BLUE, GyroData(), Timer::now());
     auto &trackers = groups.front()->data();
     EXPECT_TRUE(trackers.empty());
     EXPECT_TRUE(info.combos.empty());
@@ -53,7 +53,7 @@ TEST_F(ArmorDetectorTest, single_armor_more_blob_disturb)
     buildBlobImg(-15, cv::Point(1000, 480));
     // imshow("src", src);
     // waitKey(0);
-    info = p_detector->detect(groups, src, RED, GyroData(), timer.now());
+    info = p_detector->detect(groups, src, RED, GyroData(), Timer::now());
     trackers = groups.front()->data();
     EXPECT_EQ(trackers.size(), 1);
 
@@ -67,7 +67,7 @@ TEST_F(ArmorDetectorTest, single_armor_more_blob_disturb)
     buildBlobImg(-15, cv::Point(600, 200));
     // imshow("src", src);
     // waitKey(0);
-    info = p_detector->detect(groups, src, RED, GyroData(), timer.now());
+    info = p_detector->detect(groups, src, RED, GyroData(), Timer::now());
     trackers = groups.front()->data();
     EXPECT_EQ(trackers.size(), 1);
 
@@ -82,7 +82,7 @@ TEST_F(ArmorDetectorTest, single_armor_more_blob_disturb)
     buildBlobImg(-10, cv::Point(1000, 450));
     // imshow("src", src);
     // waitKey(0);
-    info = p_detector->detect(groups, src, RED, GyroData(), timer.now());
+    info = p_detector->detect(groups, src, RED, GyroData(), Timer::now());
     EXPECT_EQ(groups.size(), 1);
 
     if (info.combos.size() == 1)
@@ -98,7 +98,7 @@ TEST_F(ArmorDetectorTest, more_armor_independence)
     buildArmorImg(cv::Point(500, 300), 0);
     buildArmorImg(cv::Point(800, 500), -7);
 
-    auto info = p_detector->detect(groups, src, RED, GyroData(), timer.now());
+    auto info = p_detector->detect(groups, src, RED, GyroData(), Timer::now());
 
     sort(info.combos.begin(), info.combos.end(),
          [](const combo::ptr &lhs, const combo::ptr &rhs) {
@@ -126,7 +126,7 @@ TEST_F(ArmorDetectorTest, more_armor_disturb)
     buildBlobImg(0, cv::Point(205, 500));
     // imshow("src", src);
     // waitKey(0);
-    auto info = p_detector->detect(groups, src, BLUE, GyroData(), timer.now());
+    auto info = p_detector->detect(groups, src, BLUE, GyroData(), Timer::now());
     EXPECT_TRUE(info.combos.empty());
     // 正对 2 装甲板倾角相反
     reset();
@@ -134,7 +134,7 @@ TEST_F(ArmorDetectorTest, more_armor_disturb)
     buildArmorImg(cv::Point(800, 500), -8);
     // imshow("src", src);
     // waitKey(0);
-    info = p_detector->detect(groups, src, RED, GyroData(), timer.now());
+    info = p_detector->detect(groups, src, RED, GyroData(), Timer::now());
 
     EXPECT_EQ(info.combos.size(), 2);
     // 2 装甲板上下相距较近、有部分交错
@@ -143,7 +143,7 @@ TEST_F(ArmorDetectorTest, more_armor_disturb)
     buildArmorImg(cv::Point(440, 400), 3);
     // imshow("src", src);
     // waitKey(0);
-    info = p_detector->detect(groups, src, RED, GyroData(), timer.now());
+    info = p_detector->detect(groups, src, RED, GyroData(), Timer::now());
 
     EXPECT_EQ(info.combos.size(), 2);
 }

--- a/extra/detector/test/armor_match_test.cpp
+++ b/extra/detector/test/armor_match_test.cpp
@@ -25,10 +25,10 @@ TEST_F(ArmorDetectorTest, more_tracker_match_less_armor)
 {
     buildArmorImg(cv::Point(200, 800), -5.f);
     buildArmorImg(cv::Point(600, 400), 5.f);
-    p_detector->detect(groups, src, RED, GyroData(), timer.now());
+    p_detector->detect(groups, src, RED, GyroData(), Timer::now());
     resetImg();
     buildArmorImg(cv::Point(610, 405), 3.f);
-    auto info = p_detector->detect(groups, src, RED, GyroData(), timer.now());
+    auto info = p_detector->detect(groups, src, RED, GyroData(), Timer::now());
 
     auto &trackers = groups.front()->data();
     EXPECT_EQ(info.combos.size(), 1);
@@ -43,10 +43,10 @@ TEST_F(ArmorDetectorTest, tracker_match_an_equal_number_of_armor)
 {
     // 1 追踪器 1 帧间距离较近的装甲板
     buildArmorImg(cv::Point(200, 800), -5.f);
-    auto info = p_detector->detect(groups, src, RED, GyroData(), timer.now());
+    auto info = p_detector->detect(groups, src, RED, GyroData(), Timer::now());
     resetImg();
     buildArmorImg(cv::Point(210, 805), -7.f);
-    p_detector->detect(groups, src, RED, GyroData(), timer.now());
+    p_detector->detect(groups, src, RED, GyroData(), Timer::now());
 
     auto &trackers = groups.front()->data();
 
@@ -55,10 +55,10 @@ TEST_F(ArmorDetectorTest, tracker_match_an_equal_number_of_armor)
     resetImg();
     resetDetector();
     buildArmorImg(cv::Point(200, 800), -5.f);
-    info = p_detector->detect(groups, src, RED, GyroData(), timer.now());
+    info = p_detector->detect(groups, src, RED, GyroData(), Timer::now());
     resetImg();
     buildArmorImg(cv::Point(1000, 200), -7.f);
-    info = p_detector->detect(groups, src, RED, GyroData(), timer.now());
+    info = p_detector->detect(groups, src, RED, GyroData(), Timer::now());
 
     trackers = groups.front()->data();
     EXPECT_EQ(info.combos.size(), 1);
@@ -72,11 +72,11 @@ TEST_F(ArmorDetectorTest, tracker_match_an_equal_number_of_armor)
 TEST_F(ArmorDetectorTest, less_tracker_match_more_armor)
 {
     buildArmorImg(cv::Point(600, 400), 5.f);
-    auto info = p_detector->detect(groups, src, RED, GyroData(), timer.now());
+    auto info = p_detector->detect(groups, src, RED, GyroData(), Timer::now());
     resetImg();
     buildArmorImg(cv::Point(200, 800), -5.f);
     buildArmorImg(cv::Point(610, 405), 3.f);
-    info = p_detector->detect(groups, src, RED, GyroData(), timer.now());
+    info = p_detector->detect(groups, src, RED, GyroData(), Timer::now());
 
     auto &trackers = groups.front()->data();
     EXPECT_EQ(info.combos.size(), 2);

--- a/extra/group/test/test_gyro_group.cpp
+++ b/extra/group/test/test_gyro_group.cpp
@@ -63,7 +63,7 @@ public:
         cv::projectPoints(world_points, rvec, tvec, cameraMatrix, distCoeffs, imagePoints);
         auto p_left = rm::LightBlob::make_feature(imagePoints[1], imagePoints[0], 10);
         auto p_right = rm::LightBlob::make_feature(imagePoints[2], imagePoints[3], 10);
-        return rm::Armor::make_combo(p_left, p_right, rm::GyroData(), rm::timer.now(), rm::ArmorSizeType::SMALL);
+        return rm::Armor::make_combo(p_left, p_right, rm::GyroData(), rm::Timer::now(), rm::ArmorSizeType::SMALL);
     }
 };
 

--- a/modules/algorithm/include/rmvl/algorithm/math.hpp
+++ b/modules/algorithm/include/rmvl/algorithm/math.hpp
@@ -33,11 +33,8 @@ namespace rm
 //! @{
 
 // --------------------【结构、类型、常量定义】--------------------
-#ifdef MAXFLOAT
-constexpr double FLOAT_MAX{MAXFLOAT};
-#elif defined HUGE
-constexpr double FLOAT_MAX{HUGE};
-#endif
+constexpr float FLOAT_MAX = std::numeric_limits<float>::max(); //!< float 最大值
+constexpr float FLOAT_MIN = std::numeric_limits<float>::min(); //!< float 最小值
 
 constexpr double PI = 3.14159265358979323; //!< 圆周率: \f$\pi\f$
 constexpr double e = 2.7182818459045;      //!< 自然对数底数: \f$e\f$

--- a/modules/core/include/rmvl/core/timer.hpp
+++ b/modules/core/include/rmvl/core/timer.hpp
@@ -51,9 +51,6 @@ private:
 
 inline std::chrono::steady_clock::time_point Timer::_tick = {};
 
-//! 全局定时器对象
-RMVL_W_RW inline Timer timer;
-
 //! @} core_timer
 
 } // namespace rm

--- a/modules/opcua/include/rmvl/opcua/event.hpp
+++ b/modules/opcua/include/rmvl/opcua/event.hpp
@@ -88,11 +88,12 @@ public:
     Event() = default;
 
     /**
-     * @brief 从事件类型构造新的事件
+     * @brief 从事件类型创建新的事件
      *
      * @param[in] etype 既存的待作为事件类型信息的使用 `rm::EventType` 表示的变量类型
+     * @return 新的事件
      */
-    Event(EventType &etype) : _type(&etype), _properties(etype.data()) {}
+    static inline Event from(const EventType &etype) { return Event(etype); }
 
     /**
      * @brief 添加非默认属性至事件类型中
@@ -123,15 +124,8 @@ public:
      */
     inline const auto &data() const { return _properties; }
 
-    /**
-     * @brief 设置事件类型
-     *
-     * @param[in] type 既存的待作为事件类型信息的使用 `rm::EventType` 表示的变量类型
-     */
-    inline void setType(EventType &type) { _type = &type; }
-
     //! 获取事件类型
-    inline const EventType *type() const { return _type; }
+    inline EventType type() const { return _type; }
 
     uint16_t ns{1U};         //!< 命名空间索引，默认为 `1`
     std::string source_name; //!< 默认属性：事件源名称
@@ -139,7 +133,9 @@ public:
     uint16_t severity{};     //!< 默认属性：事件严重程度
 
 private:
-    EventType *_type{nullptr};                        //!< 事件类型的指针
+    Event(const EventType &etype) : _type(etype), _properties(etype.data()) {}
+
+    EventType _type{};                                //!< 事件类型
     std::unordered_map<std::string, int> _properties; //!< 非默认属性列表（仅支持 `int` 整型）
 };
 

--- a/modules/opcua/include/rmvl/opcua/object.hpp
+++ b/modules/opcua/include/rmvl/opcua/object.hpp
@@ -56,6 +56,13 @@ public:
     inline void add(const Method &method) { _methods[method.browse_name] = method; }
 
     /**
+     * @brief 判断对象类型是否为空
+     * 
+     * @return 是否为空
+     */
+    inline bool empty() const { return _variables.empty() && _methods.empty() && _base == nullptr; }
+
+    /**
      * @brief 设置基类 `rm::ObjectType` 对象类型
      *
      * @param[in] otype 既存的待作为基类的 `rm::ObjectType` 对象类型
@@ -67,7 +74,7 @@ public:
      *
      * @return 基类 `rm::ObjectType`
      */
-    inline const ObjectType *getBase() const { return _base; }
+    inline const ObjectType *base() const { return _base; }
 
     inline const auto &getVariables() const { return _variables; }
 
@@ -130,17 +137,19 @@ private:
 class Object final
 {
 public:
-    Object() : _type(nullptr) {}
+    Object() = default;
 
     /**
-     * @brief 从对象类型构造新的对象节点
+     * @brief 从对象类型构创建的对象节点
      *
      * @param[in] otype 既存的待作为对象节点类型信息的使用 `rm::ObjectType` 表示的变量类型
+     * @return 新的 `rm::Object` 对象节点
      */
-    explicit Object(ObjectType &otype) : _type(&otype), _variables(otype.getVariables()), _methods(otype.getMethods()) {}
+    static inline Object from(const ObjectType &otype) { return Object(otype); }
+
 
     //! 获取对象类型 `rm::ObjectType`
-    inline const ObjectType *type() const { return _type; }
+    inline ObjectType type() const { return _type; }
 
     /**
      * @brief 添加（额外的）变量节点至 `rm::Object` 对象中
@@ -202,8 +211,10 @@ public:
     std::string description{};
 
 private:
+    explicit Object(const ObjectType &otype) : _type(otype), _variables(otype.getVariables()), _methods(otype.getMethods()) {}
+
     //! 对应的用 `rm::ObjectType` 表示的对象类型
-    ObjectType *_type;
+    ObjectType _type{};
 
     /**
      * @brief 变量节点

--- a/modules/opcua/include/rmvl/opcua/utilities.hpp
+++ b/modules/opcua/include/rmvl/opcua/utilities.hpp
@@ -16,6 +16,7 @@
 #include <typeindex>
 #include <unordered_map>
 
+#include <open62541/nodeids.h>
 #include <open62541/types_generated_handling.h>
 
 struct UA_Server;

--- a/modules/opcua/include/rmvl/opcua/variable.hpp
+++ b/modules/opcua/include/rmvl/opcua/variable.hpp
@@ -67,6 +67,8 @@ private:
     UA_UInt32 _size{};
 
 public:
+    VariableType() = default;
+
     /**
      * @brief 单值构造，设置默认值
      *
@@ -102,6 +104,9 @@ public:
     //! 获取数据类型
     inline DataType getDataType() const { return _data_type; }
 
+    //! 判断变量类型节点是否为空
+    constexpr bool empty() const { return _size == 0; }
+
     //! 获取大小 @note 未初始化则返回 `0`
     inline UA_UInt32 size() const { return _size; }
 };
@@ -132,11 +137,12 @@ public:
     Variable(const std::vector<Tp> &arr) : access_level(3U), _value(arr), _data_type(DataType(typeid(Tp))), _size(static_cast<UA_UInt32>(arr.size())) {}
 
     /**
-     * @brief 从变量类型构造新的变量节点
+     * @brief 从变量类型创建新的变量节点
      *
      * @param[in] vtype 既存的待作为变量节点类型信息的使用 `rm::VariableType` 表示的变量类型
+     * @return 新的变量节点
      */
-    explicit Variable(VariableType &vtype) : access_level(3U), _type(&vtype), _value(vtype.data()), _data_type(vtype.getDataType()), _size(vtype.size()) {}
+    static inline Variable from(const VariableType &vtype) { return Variable(vtype); }
 
     /**
      * @brief 比较两个变量是否相等，当且仅当两个变量的数据类型、维数、数据值均相等时返回
@@ -192,7 +198,7 @@ public:
      * @see _type
      * @return 变量类型
      */
-    inline const VariableType *type() const { return _type; }
+    inline const VariableType type() const { return _type; }
 
     //! 获取数据
     inline const auto &data() const { return _value; }
@@ -229,14 +235,16 @@ public:
     uint8_t access_level{};
 
 private:
+    explicit Variable(const VariableType &vtype) : access_level(3U), _type(vtype), _value(vtype.data()), _data_type(vtype.getDataType()), _size(vtype.size()) {}
+
     /**
      * @brief 对应的用 `rm::VariableType` 表示的变量类型
      * @brief
-     * - 默认情况下为 `nullptr`，添加至 `rm::Server` 时表示采用 `BaseDataVariableType` 作为其变量类型
+     * - 添加至 `rm::Server` 时表示采用 `BaseDataVariableType` 作为其变量类型
      * @brief
      * - 作为变量类型节点、变量节点之间链接的依据
      */
-    VariableType *_type{nullptr};
+    VariableType _type{};
     //! 数据
     std::any _value;
     //! 数据类型

--- a/modules/opcua/param/opcua.para
+++ b/modules/opcua/param/opcua.para
@@ -7,10 +7,11 @@ enum LogLevel # 服务器/客户端输出日志的最低级别
   LOG_FATAL   # 致命级别，输出致命错误信息
 endenum
 
+bool SERVER_WAIT = false                       # 单次处理网络事件时，允许服务器等待最多 50ms
 uint32_t CONNECT_TIMEOUT = 30000               # 请求连接时，判定为超时的时间，单位 (ms)
 LogLevel CLIENT_LOGLEVEL = LogLevel::LOG_ERROR # 客户端输出日志的最低级别
 LogLevel SERVER_LOGLEVEL = LogLevel::LOG_ERROR # 服务器输出日志的最低级别
-uint32_t SPIN_TIMEOUT = 10                     # 单次 run_iterate 服务器超时响应的时间，单位 (ms)
+uint32_t CLIENT_WAIT_TIMEOUT = 10              # 单次处理网络事件时，允许客户端等待的时间，单位 (ms)
 
 double SAMPLING_INTERVAL = 2      # 服务器监视变量的采样速度，单位 (ms)，不得小于 2ms
 double PUBLISHING_INTERVAL = 2    # 服务器尝试发布数据变更的期望时间间隔，若数据未变更则不会发布，单位 (ms)，不得小于 2ms

--- a/modules/opcua/test/test_opcua_server.cpp
+++ b/modules/opcua/test/test_opcua_server.cpp
@@ -45,7 +45,7 @@ TEST(OPC_UA_Server, add_variable_node)
     variable.display_name = "测试双精度浮点数";
     auto node = srv.addVariableNode(variable);
     EXPECT_FALSE(UA_NodeId_isNull(&node));
-    srv.start();
+    srv.spinOnce();
 }
 
 TEST(OPC_UA_Server, variable_node_io)
@@ -53,7 +53,7 @@ TEST(OPC_UA_Server, variable_node_io)
     rm::Server srv(4820, "TestServer");
     uaCreateVariable(variable, 1);
     auto node = srv.addVariableNode(variable);
-    srv.start();
+    srv.spinOnce();
     EXPECT_EQ(srv.read(node), 1);
     EXPECT_TRUE(srv.write(node, 2));
     EXPECT_EQ(srv.read(node), 2);
@@ -75,7 +75,7 @@ TEST(OPC_UA_Server, add_data_source_variable_node)
     };
     auto node = srv.addDataSourceVariableNode(variable, on_read, on_write);
     EXPECT_FALSE(UA_NodeId_isNull(&node));
-    srv.start();
+    srv.spinOnce();
 }
 
 // 服务器添加变量类型节点
@@ -88,7 +88,7 @@ TEST(OPC_UA_Server, add_variable_type_node)
     variable_type.display_name = "测试字符串";
     auto node = srv.addVariableTypeNode(variable_type);
     EXPECT_FALSE(UA_NodeId_isNull(&node));
-    srv.start();
+    srv.spinOnce();
 }
 
 // 服务器添加方法节点
@@ -100,7 +100,7 @@ TEST(OPC_UA_Server, add_method_node)
     method.description = "this is test method";
     method.display_name = "测试方法";
     srv.addMethodNode(method);
-    srv.start();
+    srv.spinOnce();
 }
 
 // 服务器添加对象节点
@@ -118,7 +118,7 @@ TEST(OPC_UA_Server, add_object_node)
     object.add(val1);
     auto id = srv.addObjectNode(object);
     EXPECT_FALSE(UA_NodeId_isNull(&id));
-    srv.start();
+    srv.spinOnce();
 }
 
 // 服务器添加包含方法节点的对象节点
@@ -142,7 +142,7 @@ TEST(OPC_UA_Server, add_object_node_with_method)
     object.add(method);
     auto id = srv.addObjectNode(object);
     EXPECT_FALSE(UA_NodeId_isNull(&id));
-    srv.start();
+    srv.spinOnce();
 }
 
 // 服务器添加对象类型节点
@@ -160,7 +160,7 @@ TEST(OPC_UA_Server, add_object_type_node)
     object_type.add(val1);
     auto id = srv.addObjectTypeNode(object_type);
     EXPECT_FALSE(UA_NodeId_isNull(&id));
-    srv.start();
+    srv.spinOnce();
 }
 
 // 从对象类型节点派生对象节点，并添加到服务器
@@ -177,13 +177,13 @@ TEST(OPC_UA_Server, create_object_by_object_type)
     val1.display_name = "测试变量 1";
     object_type.add(val1);
     srv.addObjectTypeNode(object_type);
-    rm::Object object(object_type);
+    auto object = rm::Object::from(object_type);
     object.browse_name = "test_object";
     object.description = "this is test object";
     object.display_name = "测试对象";
     auto id = srv.addObjectNode(object);
     EXPECT_FALSE(UA_NodeId_isNull(&id));
-    srv.start();
+    srv.spinOnce();
 }
 
 // 服务器节点服务端路径搜索
@@ -202,7 +202,7 @@ TEST(OPC_UA_Server, find_node)
     auto id = srv.addObjectNode(object);
     auto target = rm::nodeObjectsFolder | srv.find("test_object");
     EXPECT_TRUE(UA_NodeId_equal(&id, &target));
-    srv.start();
+    srv.spinOnce();
 }
 
 // 添加自定义事件类型节点
@@ -218,7 +218,7 @@ TEST(OPC_UA_Server, add_event_type_node)
     auto id = srv.addEventTypeNode(event_type);
     auto target = rm::nodeBaseEventType | srv.find("test_event_type");
     EXPECT_TRUE(UA_NodeId_equal(&id, &target));
-    srv.start();
+    srv.spinOnce();
 }
 
 // 手动触发事件
@@ -234,21 +234,21 @@ TEST(OPC_UA_Server, trigger_event)
     event_type.add("test_val", val);
     srv.addEventTypeNode(event_type);
     // 创建事件
-    rm::Event event(event_type);
+    auto event = rm::Event::from(event_type);
     event.source_name = "test_event";
     event.message = "this is test event";
     event.severity = 1;
     event["test_val1"] = 99;
     // 触发事件
     EXPECT_TRUE(srv.triggerEvent(UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER), event));
-    srv.start();
+    srv.spinOnce();
 }
 
 // 从函数指针配置服务器
 TEST(OPC_UA_Server, function_ptr)
 {
     rm::Server srv(testnum, 4865);
-    srv.start();
+    srv.spinOnce();
     auto id = rm::nodeObjectsFolder | srv.find("TestNumber");
     EXPECT_FALSE(UA_NodeId_isNull(&id));
 }
@@ -263,7 +263,7 @@ TEST(OPC_UA_Server, view_node)
     srv.addVariableNode(demo2);
     uaCreateVariable(demo3, "abc");
     auto node3 = srv.addVariableNode(demo3);
-    srv.start();
+    srv.spinOnce();
 
     rm::View view;
     view.add(node1, node3);
@@ -273,6 +273,26 @@ TEST(OPC_UA_Server, view_node)
     auto view_id = srv.addViewNode(view);
     auto target_view_id = rm::nodeViewsFolder | srv.find("test_view");
     EXPECT_TRUE(UA_NodeId_equal(&view_id, &target_view_id));
+}
+
+TEST(OPC_UA_Server, timer_test)
+{
+    rm::Server srv(4875);
+    uaCreateVariable(val, 0);
+    auto nd = srv.addVariableNode(val);
+    srv.spinOnce();    
+
+    int times{};
+
+    auto timer = rm::ServerTimer(srv, 50, [&](rm::ServerView sv) {
+        int num = sv.read(nd).cast<int>() + 10;
+        sv.write(nd, num);
+        times++;
+    });
+
+    while (times != 5)
+        srv.spinOnce();
+    EXPECT_EQ(srv.read(nd).cast<int>(), 50);
 }
 
 } // namespace rm_test

--- a/samples/opcua/opcua_server.cpp
+++ b/samples/opcua/opcua_server.cpp
@@ -6,7 +6,7 @@ using namespace rm;
 
 Server server(4840);
 
-static inline void onHandle(int) { server.stop(); }
+static inline void onHandle(int) { server.shutdown(); }
 
 int main()
 {
@@ -30,7 +30,6 @@ int main()
     server.addVariableNode(value_1);
     server.addVariableNode(value_2);
     server.addMethodNode(add);
-    server.start();
     printf("节点信息:\n");
     printf("  ObjectFolders:\n");
     printf("  - value_1:\n");
@@ -45,6 +44,6 @@ int main()
     printf("      node: Method\n");
     printf("      input: num1(Int32), num2(Int32)\n");
     printf("      output: result(Int32)\n");
-    server.join();
+    server.spin();
     return 0;
 }


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 为 `rm::Client` 和 `rm::Server` 增加循环定时器 `rm::ClientTimer` 和 `rm::ServerTimer`，并支持与 `std::function<void(rm::ServerView)>` 相兼容的所有可调用对象
- 修改 `rm::Server` 的服务启动方式和终止方式，引入阻塞式的事件循环 `spin` 和单次处理到达事件的 `spinOnce` 两种启动方式，引入 `shutdown` 用于停止事件循环，并停止网络层。将默认的多线程方式移除（避免带来嵌套事件循环的错误），使用详情可继续参考[文档](https://cv-rmvl.github.io/docs/2.x/db/dba/tutorial_modules_opcua.html)
- 同步文档，增加 OPC UA 循环定时器相关的使用说明

### 注意事项

- 对于 1.4.0 及以上版本的 open62541 库，使用 rm::ClientTimer 时极容易出现循环触发事件循环的错误，待排查解决