### PR TITLE
🔧 修改识别模块图像传入接口

### DIFF
--- a/extra/detector/include/rmvl/detector/armor_detector.h
+++ b/extra/detector/include/rmvl/detector/armor_detector.h
@@ -52,8 +52,7 @@ public:
      * @param[in] tick 当前时间点
      * @return 识别信息结构体
      */
-    DetectInfo detect(std::vector<group::ptr> &groups, cv::Mat &src, PixChannel color,
-                      const ImuData &imu_data, double tick) override;
+    DetectInfo detect(std::vector<group::ptr> &groups, const cv::Mat &src, PixChannel color, const ImuData &imu_data, double tick) override;
 
     //! 构建 ArmorDetector
     static inline std::unique_ptr<ArmorDetector> make_detector() { return std::make_unique<ArmorDetector>(); }

--- a/extra/detector/include/rmvl/detector/detector.h
+++ b/extra/detector/include/rmvl/detector/detector.h
@@ -34,7 +34,7 @@ struct DetectInfo
     cv::Mat gray;              //!< 灰度图列表
     cv::Mat bin;               //!< 二值图列表
     std::vector<cv::Mat> rois; //!< ROI 列表
-    cv::Mat rendergraphs;      //!< 渲染图列表
+    cv::Mat rendergraph;       //!< 渲染图
 
     std::vector<combo::ptr> combos;     //!< 当前帧所有组合体
     std::vector<feature::ptr> features; //!< 当前帧所有特征
@@ -44,7 +44,7 @@ struct DetectInfo
 class detector
 {
 protected:
-    double _tick;        //!< 每一帧对应的时间点
+    double _tick;      //!< 每一帧对应的时间点
     ImuData _imu_data; //!< 每一帧对应的 IMU 数据
 
 public:
@@ -64,8 +64,7 @@ public:
      * @param[in] tick 当前时间点
      * @return 识别信息结构体
      */
-    virtual DetectInfo detect(std::vector<group::ptr> &groups, cv::Mat &src, PixChannel color,
-                              const ImuData &imu_data, double tick) = 0;
+    virtual DetectInfo detect(std::vector<group::ptr> &groups, const cv::Mat &src, PixChannel color, const ImuData &imu_data, double tick) = 0;
 };
 
 //! @} detector

--- a/extra/detector/include/rmvl/detector/gyro_detector.h
+++ b/extra/detector/include/rmvl/detector/gyro_detector.h
@@ -53,8 +53,7 @@ public:
      * @param[in] tick 当前时间点
      * @return 识别信息结构体
      */
-    DetectInfo detect(std::vector<group::ptr> &groups, cv::Mat &src, rm::PixChannel color,
-                      const ImuData &imu_data, double tick) override;
+    DetectInfo detect(std::vector<group::ptr> &groups, const cv::Mat &src, rm::PixChannel color, const ImuData &imu_data, double tick) override;
 
     //! 构建 GyroDetector
     static inline std::unique_ptr<GyroDetector> make_detector(int armor_num = 0)

--- a/extra/detector/include/rmvl/detector/rune_detector.h
+++ b/extra/detector/include/rmvl/detector/rune_detector.h
@@ -36,8 +36,7 @@ public:
      * @param[in] tick 当前时间点
      * @return 识别信息结构体
      */
-    DetectInfo detect(std::vector<group::ptr> &groups, cv::Mat &src, PixChannel color,
-                      const ImuData &imu_data, double tick) override;
+    DetectInfo detect(std::vector<group::ptr> &groups, const cv::Mat &src, PixChannel color, const ImuData &imu_data, double tick) override;
 
     //! 构建 RuneDetector
     static inline std::unique_ptr<RuneDetector> make_detector() { return std::make_unique<RuneDetector>(); }

--- a/extra/detector/include/rmvl/detector/tag_detector.h
+++ b/extra/detector/include/rmvl/detector/tag_detector.h
@@ -62,8 +62,7 @@ public:
      * @param[in] imu_data 当前 IMU 数据
      * @param[in] tick 当前时间点
      */
-    DetectInfo detect(std::vector<group::ptr> &groups, cv::Mat &src, PixChannel color,
-                      const ImuData &imu_data, double tick) override;
+    DetectInfo detect(std::vector<group::ptr> &groups, const cv::Mat &src, PixChannel color, const ImuData &imu_data, double tick) override;
 
 private:
     /**

--- a/extra/detector/src/armor_detector/detect.cpp
+++ b/extra/detector/src/armor_detector/detect.cpp
@@ -16,8 +16,7 @@
 namespace rm
 {
 
-DetectInfo ArmorDetector::detect(std::vector<group::ptr> &groups, cv::Mat &src, PixChannel color,
-                                 const ImuData &imu_data, double tick)
+DetectInfo ArmorDetector::detect(std::vector<group::ptr> &groups, const cv::Mat &src, PixChannel color, const ImuData &imu_data, double tick)
 {
     DetectInfo info{};
     info.src = src;

--- a/extra/detector/src/gyro_detector/detect.cpp
+++ b/extra/detector/src/gyro_detector/detect.cpp
@@ -17,7 +17,7 @@
 namespace rm
 {
 
-DetectInfo GyroDetector::detect(std::vector<group::ptr> &groups, cv::Mat &src, PixChannel color,
+DetectInfo GyroDetector::detect(std::vector<group::ptr> &groups, const cv::Mat &src, PixChannel color,
                                 const ImuData &imu_data, double tick)
 {
     // 识别信息

--- a/extra/detector/src/rune_detector/detect.cpp
+++ b/extra/detector/src/rune_detector/detect.cpp
@@ -17,8 +17,7 @@
 namespace rm
 {
 
-DetectInfo RuneDetector::detect(std::vector<group::ptr> &groups, cv::Mat &src, PixChannel color,
-                                const ImuData &imu_data, double tick)
+DetectInfo RuneDetector::detect(std::vector<group::ptr> &groups, const cv::Mat &src, PixChannel color, const ImuData &imu_data, double tick)
 {
     if (groups.size() > 1)
         RMVL_Error(RMVL_StsBadArg, "Size of the argument \"groups\" is greater than 1");

--- a/extra/detector/src/tag_detector/detect.cpp
+++ b/extra/detector/src/tag_detector/detect.cpp
@@ -39,8 +39,7 @@ TagDetector::~TagDetector()
     tag25h9_destroy(_tf);
 }
 
-DetectInfo TagDetector::detect(std::vector<group::ptr> &groups, cv::Mat &src, PixChannel,
-                               const ImuData &imu_data, double tick)
+DetectInfo TagDetector::detect(std::vector<group::ptr> &groups, const cv::Mat &src, PixChannel, const ImuData &imu_data, double tick)
 {
     DetectInfo info;
     info.src = src;

--- a/extra/group/include/rmvl/group/group.h
+++ b/extra/group/include/rmvl/group/group.h
@@ -113,7 +113,7 @@ public:
     inline RMStatus type() const { return _type; }
 };
 
-#define RMVL_GROUP_CAST(name)                                                                           \
+#define RMVL_GROUP_CAST(name)                                                                       \
     static inline ptr cast(group::ptr p_group) { return std::dynamic_pointer_cast<name>(p_group); } \
     static inline const_ptr cast(group::const_ptr p_group) { return std::dynamic_pointer_cast<const name>(p_group); }
 


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 原先识别模块图像传入的方式是 `cv::Mat &`，现改为 `const cv::Mat &`