### PR TITLE
🐞 修复 Galaxy 系列相机在 Linux 平台无法 find_package 的问题

### DIFF
--- a/cmake/FindGalaxySDK.cmake
+++ b/cmake/FindGalaxySDK.cmake
@@ -15,14 +15,6 @@ if(NOT DEFINED galaxy_sdk_path)
   endif()
 endif()
 
-# add the include directories path
-find_path(
-  GalaxySDK_INCLUDE_DIR
-  NAMES GxIAPI.h DxImageProc.h
-  PATHS "${galaxy_sdk_path}/Development/VC SDK/inc"
-  NO_DEFAULT_PATH
-)
-
 # add libraries
 if(UNIX)
   if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "amd64")
@@ -35,6 +27,12 @@ if(UNIX)
     return()
   endif()
 
+  find_path(
+    GalaxySDK_INCLUDE_DIR
+    NAMES GxIAPI.h DxImageProc.h
+    PATHS "${galaxy_sdk_path}/inc"
+    NO_DEFAULT_PATH
+  )
   find_library(
     GalaxySDK_LIB
     NAMES "libgxiapi.so"
@@ -50,13 +48,18 @@ if(UNIX)
     )
   endif()
 elseif(WIN32)
+  find_path(
+    GalaxySDK_INCLUDE_DIR
+    NAMES GxIAPI.h DxImageProc.h
+    PATHS "${galaxy_sdk_path}/Development/VC SDK/inc"
+    NO_DEFAULT_PATH
+  )
   find_library(
     GalaxySDK_LIB
     NAMES GxIAPI.lib DxImageProc.lib
     PATHS "${galaxy_sdk_path}/Development/VC SDK/lib/x${sys_type}"
     NO_DEFAULT_PATH
   )
-
   find_file(
     GalaxySDK_DLL
     NAMES GxIAPI.dll DxImageProc.dll

--- a/modules/camera/src/mv_camera/mv_camera_impl.h
+++ b/modules/camera/src/mv_camera/mv_camera_impl.h
@@ -1,5 +1,5 @@
 /**
- * @file mv_camera_MvCameraImpl.h
+ * @file mv_camera_impl.h
  * @author zhaoxi (535394140@qq.com)
  * @brief 工业相机实现
  * @version 1.0


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 原先的 `FindGalaxySDK.cmake` 文件中，在添加了 Windows 路径支持后，将原先 UNIX 平台头文件搜索路径的寻找规则给覆盖了，现予以修正