### PR TITLE
🔧 为 tracker 模块增加 `invalid` 接口

### DIFF
--- a/extra/detector/include/rmvl/detector/armor_detector.h
+++ b/extra/detector/include/rmvl/detector/armor_detector.h
@@ -129,20 +129,6 @@ private:
      * @param[in] combos 每一帧的所有目标
      */
     void matchArmors(std::vector<tracker::ptr> &trackers, const std::vector<combo::ptr> &combos);
-
-    /**
-     * @brief 及时删除多帧为空的序列
-     *
-     * @param[in out] trackers 所有追踪器序列
-     */
-    void eraseNullTracker(std::vector<tracker::ptr> &trackers);
-
-    /**
-     * @brief 删除因数字识别判断出的伪装甲板序列
-     *
-     * @param[in out] trackers 所有追踪器序列
-     */
-    void eraseFakeTracker(std::vector<tracker::ptr> &trackers);
 };
 
 //! @} armor_detector

--- a/extra/detector/include/rmvl/detector/tag_detector.h
+++ b/extra/detector/include/rmvl/detector/tag_detector.h
@@ -63,22 +63,6 @@ public:
      * @param[in] tick 当前时间点
      */
     DetectInfo detect(std::vector<group::ptr> &groups, const cv::Mat &src, PixChannel color, const ImuData &imu_data, double tick) override;
-
-private:
-    /**
-     * @brief Tag 特征组合体匹配至时间序列
-     *
-     * @param[in out] trackers 所有追踪器序列
-     * @param[in] combos 每一帧的所有目标
-     */
-    void match(std::vector<tracker::ptr> &trackers, const std::vector<combo::ptr> &combos);
-
-    /**
-     * @brief 及时删除多帧为空的序列
-     *
-     * @param[in out] trackers 所有追踪器序列
-     */
-    void eraseNullTracker(std::vector<tracker::ptr> &trackers);
 };
 
 //! @} tag_detector

--- a/extra/detector/src/gyro_detector/match.cpp
+++ b/extra/detector/src/gyro_detector/match.cpp
@@ -9,12 +9,13 @@
  *
  */
 
+#include "rmvl/core/datastruct.hpp"
 #include "rmvl/detector/gyro_detector.h"
 #include "rmvl/group/gyro_group.h"
-#include "rmvl/core/datastruct.hpp"
 
 #include "rmvlpara/camera/camera.h"
 #include "rmvlpara/detector/gyro_detector.h"
+#include "rmvlpara/group/gyro_group.h"
 
 namespace rm
 {
@@ -30,7 +31,7 @@ static inline bool canBeUnion(const combo::ptr &lhs, const combo::ptr &rhs)
 {
     // 宽度比值
     float width_ratio = (lhs->width() > rhs->width()) ? lhs->width() / rhs->width()
-                                                            : rhs->width() / lhs->width();
+                                                      : rhs->width() / lhs->width();
     if (width_ratio > para::gyro_detector_param.MAX_WIDTH_RATIO)
     {
         DEBUG_INFO_("can't be union: width_ratio = %f", width_ratio);
@@ -38,7 +39,7 @@ static inline bool canBeUnion(const combo::ptr &lhs, const combo::ptr &rhs)
     }
     // 高度比值
     float height_ratio = (lhs->height() > rhs->height()) ? lhs->height() / rhs->height()
-                                                               : rhs->height() / lhs->height();
+                                                         : rhs->height() / lhs->height();
     if (height_ratio > para::gyro_detector_param.MAX_HEIGHT_RATIO)
     {
         DEBUG_INFO_("can't be union: height_ratio = %f", height_ratio);
@@ -237,10 +238,7 @@ void GyroDetector::match(std::vector<group::ptr> &groups, std::vector<combo::ptr
                      groups.end());
     }
     // 删除四个 tracker 同时消失数量过多的 group
-    groups.erase(remove_if(groups.begin(), groups.end(), [](group::const_ptr p_group) {
-                     return p_group->getVanishNumber() > para::gyro_group_param.TRACK_FRAMES;
-                 }),
-                 groups.end());
+    groups.erase(remove_if(groups.begin(), groups.end(), [](group::const_ptr val) { return val->invalid(); }), groups.end());
     // 删除 2D 中心点相距过近的 group
     sort(groups.begin(), groups.end(), [](group::const_ptr lhs, group::const_ptr rhs) {
         return lhs->center().x < rhs->center().x;

--- a/extra/detector/src/rune_detector/match.cpp
+++ b/extra/detector/src/rune_detector/match.cpp
@@ -14,8 +14,6 @@
 #include "rmvl/detector/rune_detector.h"
 #include "rmvl/group/rune_group.h"
 
-#include "rmvlpara/tracker/rune_tracker.h"
-
 namespace rm
 {
 
@@ -24,9 +22,7 @@ void RuneDetector::match(std::vector<tracker::ptr> &rune_trackers, const std::ve
     // 匹配
     this->matchRunes(rune_trackers, combos);
     // 删除
-    rune_trackers.erase(remove_if(rune_trackers.begin(), rune_trackers.end(), [](tracker::const_ptr p_tracker) {
-                            return p_tracker->getVanishNumber() >= para::rune_tracker_param.TRACK_FRAMES;
-                        }),
+    rune_trackers.erase(remove_if(rune_trackers.begin(), rune_trackers.end(), [](tracker::const_ptr p_tracker) { return p_tracker->invalid(); }),
                         rune_trackers.end());
 }
 

--- a/extra/detector/src/tag_detector/detect.cpp
+++ b/extra/detector/src/tag_detector/detect.cpp
@@ -18,7 +18,6 @@
 #include "rmvl/tracker/planar_tracker.h"
 
 #include "rmvlpara/detector/tag_detector.h"
-#include "rmvlpara/tracker/planar_tracker.h"
 
 #include "tag25h9.h"
 
@@ -37,6 +36,103 @@ TagDetector::~TagDetector()
 {
     apriltag_detector_destroy(_td);
     tag25h9_destroy(_tf);
+}
+
+/**
+ * @brief 判断是否突变
+ * @note 如果 Tag 在一帧内位置变化特别大, 且速度发生较大突变，则创建新序列
+ *
+ * @param[in] dis 测出的最小间距
+ * @return 是否突变
+ */
+static inline bool isChange(float dis) { return dis > para::tag_detector_param.MAX_TRACKER_DELTA_DIS; }
+
+/**
+ * @brief Tag 特征组合体匹配至时间序列
+ *
+ * @param[in out] trackers 所有追踪器序列
+ * @param[in] combos 每一帧的所有目标
+ * @param[in] tick 当前时间点
+ * @param[in] imu_data 当前 IMU 数据
+ */
+static void match(std::vector<tracker::ptr> &trackers, const std::vector<combo::ptr> &combos, double tick, const ImuData &imu_data)
+{
+    // 如果 trackers 为空先为每个识别到的 combo 开辟序列
+    if (trackers.empty())
+    {
+        for (const auto &p_combo : combos)
+            trackers.emplace_back(PlanarTracker::make_tracker(p_combo));
+        return;
+    }
+
+    // 如果当前帧识别到的视觉标签 `rm::Tag` 数量 > 序列数量
+    if (combos.size() > trackers.size())
+    {
+        // 初始化视觉标签 `rm::Tag` 集合
+        std::unordered_set<combo::ptr> tag_set(combos.begin(), combos.end());
+        // 距离最近的视觉标签 `rm::Tag` 匹配到相应的序列中, 并 update
+        for (auto p_tracker : trackers)
+        {
+            // 离 p_tracker 最近的 combo 及其距离
+            auto min_it = min_element(combos.begin(), combos.end(), [&](combo::const_ptr lhs, combo::const_ptr rhs) {
+                return getDistance(lhs->center(), p_tracker->front()->center()) <
+                       getDistance(rhs->center(), p_tracker->front()->center());
+            });
+            p_tracker->update(*min_it);
+            tag_set.erase(*min_it);
+        }
+        // 没有匹配到的视觉标签 `rm::Tag` 作为新的序列
+        for (const auto &p_combo : tag_set)
+            trackers.emplace_back(PlanarTracker::make_tracker(p_combo));
+    }
+    // 如果当前帧识别到的视觉标签 `rm::Tag` 数量 < 序列数量
+    else if (combos.size() < trackers.size())
+    {
+        // 初始化追踪器集合
+        std::unordered_set<tracker::ptr> tracker_set(trackers.begin(), trackers.end());
+        for (const auto &p_combo : combos)
+        {
+            // 离视觉标签最近的 tracker 及其距离
+            auto min_dis_tracker = *min_element(trackers.begin(), trackers.end(), [&](tracker::const_ptr lhs, tracker::const_ptr rhs) {
+                return getDistance(p_combo->center(), lhs->front()->center()) <
+                       getDistance(p_combo->center(), rhs->front()->center());
+            });
+            min_dis_tracker->update(p_combo);
+            tracker_set.erase(min_dis_tracker);
+        }
+        // 没有匹配到的序列传入 nullptr
+        for (auto p_tracker : tracker_set)
+            p_tracker->update(tick, imu_data);
+    }
+    // 如果当前帧识别到的视觉标签 `rm::Tag` 数量 = 序列数量
+    else
+    {
+        // 初始化视觉标签 `rm::Tag` 集合
+        std::unordered_set<combo::ptr> tag_set(combos.begin(), combos.end());
+        // 防止出现迭代器非法化的情况，此处使用下标访问
+        size_t before_size = trackers.size(); // 存储原始 trackers 大小
+        for (size_t i = 0; i < before_size; i++)
+        {
+            // 离 tracker 最近的 combo
+            auto min_it = *min_element(tag_set.begin(), tag_set.end(), [&](combo::const_ptr combo_1, combo::const_ptr combo_2) {
+                return getDistance(combo_1->center(), trackers[i]->front()->center()) <
+                       getDistance(combo_2->center(), trackers[i]->front()->center());
+            });
+            // 最短距离
+            float min_dis = getDistance(min_it->center(), trackers[i]->front()->center());
+            // 判断是否突变
+            //! @todo 这段掉帧处理需要增加其他信息，保证 tracker 的匹配正确
+            if (isChange(min_dis))
+            {
+                // 创建新序列，原来的序列打入 nullptr
+                trackers[i]->update(tick, imu_data);
+                trackers.emplace_back(PlanarTracker::make_tracker(min_it));
+            }
+            else
+                trackers[i]->update(min_it);
+            tag_set.erase(min_it);
+        }
+    }
 }
 
 DetectInfo TagDetector::detect(std::vector<group::ptr> &groups, const cv::Mat &src, PixChannel, const ImuData &imu_data, double tick)
@@ -98,108 +194,13 @@ DetectInfo TagDetector::detect(std::vector<group::ptr> &groups, const cv::Mat &s
     group::ptr p_group = groups.front();
     auto &trackers = p_group->data();
     // combo 匹配 tracker
-    match(trackers, info.combos);
-    // 删除 tracker
-    eraseNullTracker(trackers);
-    return info;
-}
-
-/**
- * @brief 判断是否突变
- * @note 如果 Tag 在一帧内位置变化特别大, 且速度发生较大突变，则创建新序列
- *
- * @param dis 测出的最小间距
- * @return 是否突变
- */
-static inline bool isChange(float dis) { return dis > para::tag_detector_param.MAX_TRACKER_DELTA_DIS; }
-
-void TagDetector::match(std::vector<tracker::ptr> &trackers, const std::vector<combo::ptr> &combos)
-{
-    // 如果 trackers 为空先为每个识别到的 combo 开辟序列
-    if (trackers.empty())
-    {
-        for (const auto &p_combo : combos)
-            trackers.emplace_back(PlanarTracker::make_tracker(p_combo));
-        return;
-    }
-
-    // 如果当前帧识别到的视觉标签 `rm::Tag` 数量 > 序列数量
-    if (combos.size() > trackers.size())
-    {
-        // 初始化视觉标签 `rm::Tag` 集合
-        std::unordered_set<combo::ptr> tag_set(combos.begin(), combos.end());
-        // 距离最近的视觉标签 `rm::Tag` 匹配到相应的序列中, 并 update
-        for (auto p_tracker : trackers)
-        {
-            // 离 p_tracker 最近的 combo 及其距离
-            auto min_it = min_element(combos.begin(), combos.end(), [&](combo::const_ptr lhs, combo::const_ptr rhs) {
-                return getDistance(lhs->center(), p_tracker->front()->center()) <
-                       getDistance(rhs->center(), p_tracker->front()->center());
-            });
-            p_tracker->update(*min_it);
-            tag_set.erase(*min_it);
-        }
-        // 没有匹配到的视觉标签 `rm::Tag` 作为新的序列
-        for (const auto &p_combo : tag_set)
-            trackers.emplace_back(PlanarTracker::make_tracker(p_combo));
-    }
-    // 如果当前帧识别到的视觉标签 `rm::Tag` 数量 < 序列数量
-    else if (combos.size() < trackers.size())
-    {
-        // 初始化追踪器集合
-        std::unordered_set<tracker::ptr> tracker_set(trackers.begin(), trackers.end());
-        for (const auto &p_combo : combos)
-        {
-            // 离视觉标签最近的 tracker 及其距离
-            auto min_dis_tracker = *min_element(trackers.begin(), trackers.end(), [&](tracker::const_ptr lhs, tracker::const_ptr rhs) {
-                return getDistance(p_combo->center(), lhs->front()->center()) <
-                       getDistance(p_combo->center(), rhs->front()->center());
-            });
-            min_dis_tracker->update(p_combo);
-            tracker_set.erase(min_dis_tracker);
-        }
-        // 没有匹配到的序列传入 nullptr
-        for (auto p_tracker : tracker_set)
-            p_tracker->update(_tick, _imu_data);
-    }
-    // 如果当前帧识别到的视觉标签 `rm::Tag` 数量 = 序列数量
-    else
-    {
-        // 初始化视觉标签 `rm::Tag` 集合
-        std::unordered_set<combo::ptr> tag_set(combos.begin(), combos.end());
-        // 防止出现迭代器非法化的情况，此处使用下标访问
-        size_t before_size = trackers.size(); // 存储原始 trackers 大小
-        for (size_t i = 0; i < before_size; i++)
-        {
-            // 离 tracker 最近的 combo
-            auto min_it = *min_element(tag_set.begin(), tag_set.end(), [&](combo::const_ptr combo_1, combo::const_ptr combo_2) {
-                return getDistance(combo_1->center(), trackers[i]->front()->center()) <
-                       getDistance(combo_2->center(), trackers[i]->front()->center());
-            });
-            // 最短距离
-            float min_dis = getDistance(min_it->center(), trackers[i]->front()->center());
-            // 判断是否突变
-            //! @todo 这段掉帧处理需要增加其他信息，保证 tracker 的匹配正确
-            if (isChange(min_dis))
-            {
-                // 创建新序列，原来的序列打入 nullptr
-                trackers[i]->update(_tick, _imu_data);
-                trackers.emplace_back(PlanarTracker::make_tracker(min_it));
-            }
-            else
-                trackers[i]->update(min_it);
-            tag_set.erase(min_it);
-        }
-    }
-}
-
-void TagDetector::eraseNullTracker(std::vector<tracker::ptr> &trackers)
-{
-    // 删除
+    match(trackers, info.combos, _tick, _imu_data);
+    // 删除无效 tracker
     trackers.erase(remove_if(trackers.begin(), trackers.end(), [](tracker::const_ptr p_tracker) {
-                       return p_tracker->getVanishNumber() >= para::planar_tracker_param.TRACK_FRAMES;
+                       return p_tracker->invalid();
                    }),
                    trackers.end());
+    return info;
 }
 
 } // namespace rm

--- a/extra/group/include/rmvl/group/group.h
+++ b/extra/group/include/rmvl/group/group.h
@@ -62,6 +62,9 @@ public:
      */
     virtual void add(tracker::ptr p_tracker) { _trackers.emplace_back(p_tracker); }
 
+    //! 判断是否为无效序列组
+    virtual bool invalid() const { return false; }
+
     /**
      * @brief 获取同组所有的追踪器数据
      * @note 若仅需要对 `vector<tracker::ptr>` 做数据处理，使用此方法可直接实现 group 至 tracker 的退化

--- a/extra/group/include/rmvl/group/gyro_group.h
+++ b/extra/group/include/rmvl/group/gyro_group.h
@@ -17,8 +17,6 @@
 #include "rmvl/group/group.h"
 #include "rmvl/group/gyro/utils.h"
 
-#include "rmvlpara/group/gyro_group.h"
-
 namespace rm
 {
 
@@ -74,6 +72,9 @@ public:
      */
     group::ptr clone() override;
 
+    //! 判断是否为无效序列组
+    bool invalid() const override;
+
     RMVL_GROUP_CAST(GyroGroup)
 
     /**
@@ -114,7 +115,7 @@ public:
      * @param[in] imu_data 最新 IMU 数据
      * @param[in] tick 最新时间点
      */
-    void sync(const ImuData &imu_data, double tick);
+    void sync(const ImuData &imu_data, double tick) override;
 
     /**
      * @brief 获取追踪器状态

--- a/extra/group/src/gyro_group/calc.cpp
+++ b/extra/group/src/gyro_group/calc.cpp
@@ -17,7 +17,7 @@
 
 #include "rmvlpara/camera/camera.h"
 #include "rmvlpara/combo/armor.h"
-#include "rmvlpara/tracker/gyro_tracker.h"
+#include "rmvlpara/group/gyro_group.h"
 
 namespace rm
 {

--- a/extra/group/src/gyro_group/filter_update.cpp
+++ b/extra/group/src/gyro_group/filter_update.cpp
@@ -11,7 +11,7 @@
 
 #include "rmvl/group/gyro_group.h"
 
-#include "rmvlpara/tracker/gyro_tracker.h"
+#include "rmvlpara/group/gyro_group.h"
 
 namespace rm
 {

--- a/extra/group/src/gyro_group/init.cpp
+++ b/extra/group/src/gyro_group/init.cpp
@@ -15,6 +15,7 @@
 
 #include "rmvlpara/camera/camera.h"
 #include "rmvlpara/combo/armor.h"
+#include "rmvlpara/group/gyro_group.h"
 
 namespace rm
 {
@@ -90,5 +91,7 @@ group::ptr GyroGroup::clone()
         retval->_tracker_state[p_tracker] = _tracker_state[p_tracker];
     return retval;
 }
+
+bool GyroGroup::invalid() const { return _vanish_num > para::gyro_group_param.TRACK_FRAMES; }
 
 } // namespace rm

--- a/extra/tracker/include/rmvl/tracker/planar_tracker.h
+++ b/extra/tracker/include/rmvl/tracker/planar_tracker.h
@@ -64,6 +64,9 @@ public:
      */
     void update(combo::ptr p_combo) override;
 
+    //! 判断追踪器是否无效
+    bool invalid() const override;
+
 private:
     /**
      * @brief 将 combo 中的数据更新至 tracker

--- a/extra/tracker/include/rmvl/tracker/rune_tracker.h
+++ b/extra/tracker/include/rmvl/tracker/rune_tracker.h
@@ -79,13 +79,8 @@ public:
      */
     void update(double tick, const ImuData &imu_data) override;
 
-    /**
-     * @brief 滤波器初始化
-     *
-     * @param[in] init_angle 初始角度
-     * @param[in] init_speed 初始速度
-     */
-    void initFilter(float init_angle = 0.f, float init_speed = 0.f);
+    //! 判断追踪器是否无效
+    bool invalid() const override;
 
     //! 获取神符滤波后的角速度（角度制）
     inline float getRotatedSpeed() { return _rotated_speed; }

--- a/extra/tracker/include/rmvl/tracker/tracker.h
+++ b/extra/tracker/include/rmvl/tracker/tracker.h
@@ -64,6 +64,9 @@ public:
      */
     virtual void update(double tick, const ImuData &imu_data) = 0;
 
+    //! 判断追踪器是否无效
+    virtual bool invalid() const { return false; }
+
     //! 获取时间队列中最新的组合体
     inline combo::ptr front() const { return _combo_deque.front(); }
     //! 获取时间队列中最后的组合体

--- a/extra/tracker/src/default_tracker.cpp
+++ b/extra/tracker/src/default_tracker.cpp
@@ -41,7 +41,6 @@ tracker::ptr DefaultTracker::clone()
     return retval;
 }
 
-
 void DefaultTracker::update(combo::ptr p_combo)
 {
     updateData(p_combo);

--- a/extra/tracker/src/planar_tracker/planar_tracker.cpp
+++ b/extra/tracker/src/planar_tracker/planar_tracker.cpp
@@ -10,7 +10,6 @@
  */
 
 #include "rmvl/tracker/planar_tracker.h"
-
 #include "rmvlpara/tracker/planar_tracker.h"
 
 namespace rm
@@ -37,6 +36,8 @@ PlanarTracker::PlanarTracker(combo::ptr p_combo)
     _relative_angle = p_combo->getRelativeAngle();
     updateData(p_combo);
 }
+
+bool PlanarTracker::invalid() const { return _vanish_num >= para::planar_tracker_param.TRACK_FRAMES; }
 
 tracker::ptr PlanarTracker::clone()
 {

--- a/extra/tracker/src/rune_tracker/filter_update.cpp
+++ b/extra/tracker/src/rune_tracker/filter_update.cpp
@@ -11,21 +11,10 @@
  */
 
 #include "rmvl/tracker/rune_tracker.h"
-
 #include "rmvlpara/tracker/rune_tracker.h"
 
 namespace rm
 {
-
-void RuneTracker::initFilter(float init_angle, float init_speed)
-{
-    auto first_combo = _combo_deque.front();
-
-    // 初始化旋转滤波器
-    _filter.setR({para::rune_tracker_param.ROTATE_R});
-    _filter.setQ(para::rune_tracker_param.ROTATE_Q);
-    _filter.init({init_angle, init_speed}, 1e5f);
-}
 
 void RuneTracker::updateRotateFilter(float t)
 {

--- a/extra/tracker/src/rune_tracker/rune_tracker.cpp
+++ b/extra/tracker/src/rune_tracker/rune_tracker.cpp
@@ -31,11 +31,16 @@ RuneTracker::RuneTracker(combo::ptr p_rune)
     if (p_rune == nullptr)
         RMVL_Error(RMVL_StsBadArg, "Pointer of the input argument combo::ptr is null pointer");
     _combo_deque.emplace_front(p_rune);
-    initFilter(p_rune->angle(), 0.f);
+    // 初始化旋转滤波器
+    _filter.setR({para::rune_tracker_param.ROTATE_R});
+    _filter.setQ(para::rune_tracker_param.ROTATE_Q);
+    _filter.init({p_rune->angle(), 0.f}, 1e5f);
     _angle = p_rune->angle();
     _center = p_rune->center();
     updateFromRune(p_rune);
 }
+
+bool RuneTracker::invalid() const { return _vanish_num >= para::rune_tracker_param.TRACK_FRAMES; }
 
 tracker::ptr RuneTracker::clone()
 {


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 原先在识别模块中，tracker 是否无效是通过 `getVanishNumber` 来判断的，现将次判断步骤移动至 tracker 模块中，并提供 `invalid` 公共接口（虚拟函数）
- 简化了识别类的部分成员函数，能移动到 `*.cpp` 文件的都尽量移动了，并设置了 `static` 函数