### PR TITLE
🐞 SerialPort 修复无法写入的问题

### DIFF
--- a/modules/core/include/rmvl/core/serial.hpp
+++ b/modules/core/include/rmvl/core/serial.hpp
@@ -116,7 +116,7 @@ private:
      * @param[in] len 待写入字长
      * @return 是否完整写入
      */
-    ssize_t fdwrite(void *data, size_t len);
+    ssize_t fdwrite(const void *data, size_t len);
 
     /**
      * @brief 读取数据（基于文件描述符）

--- a/modules/core/src/serial.cpp
+++ b/modules/core/src/serial.cpp
@@ -106,7 +106,7 @@ void rm::SerialPort::close()
     _is_open = false;
 }
 
-ssize_t rm::SerialPort::fdwrite(void *data, size_t length)
+ssize_t rm::SerialPort::fdwrite(const void *data, size_t length)
 {
     ssize_t len_result = -1;
     if (_is_open)


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- `fdwrite` 传入的类型是 `void *`，而调用 `fdwrite` 的 `write` 传入的是 `const Tp &` 类型，类型不兼容，现予以更改，将 `fdwrite` 改为 `const void *` 类型