### PR TITLE
✨ 串口库支持直接的字符串 IO，并增加 Python 支持

### DIFF
--- a/doc/tools/pyrmvl_fns.cfg
+++ b/doc/tools/pyrmvl_fns.cfg
@@ -6,6 +6,9 @@ rm::Timer              reset           ""                      None
 rm::Timer              now             ""                      [[Current_Time]]
 rm::ImuData            write           output_file,datas       None
 rm::ImuData            read            input_file,datas        None
+rm::SerialPort         SerialPort      device[,mode]           [[con]]
+rm::SerialPort         read            ""                      res,data
+rm::SerialPort         write           data                    res
 rm::PipeServer         PipeServer      name                    [[con]]
 rm::PipeServer         read            ""                      res,data
 rm::PipeServer         write           data                    res

--- a/modules/core/include/rmvl/core/version.hpp
+++ b/modules/core/include/rmvl/core/version.hpp
@@ -13,9 +13,9 @@
 #include "rmvldef.hpp"
 
 #define RMVL_VERSION_MAJOR 2
-#define RMVL_VERSION_MINOR 1
+#define RMVL_VERSION_MINOR 2
 #define RMVL_VERSION_PATCH 0
-#define RMVL_VERSION_STATUS ""
+#define RMVL_VERSION_STATUS "-dev"
 
 #define RMVLAUX_STR_EXP(__A) #__A
 #define RMVLAUX_STR(__A) RMVLAUX_STR_EXP(__A)

--- a/modules/core/misc/python.json
+++ b/modules/core/misc/python.json
@@ -1,0 +1,12 @@
+{
+    "Serial": {
+        "bind": [
+            ".def(\"read\", [](SerialPort &s) { std::string data; return std::make_tuple(s.read(data), data); })",
+            ".def(\"write\", [](SerialPort &s, std::string_view data) { return s.write(data); })"
+        ],
+        "pyi": [
+            "def read(self) -> Tuple[bool, str]: ...",
+            "def write(self, data: str) -> bool: ..."
+        ]
+    }
+}


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [ ] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 改进串口库，增加了直接的字符串读写函数 `read` 和 `write`，并增加 Python 支持

### 本地测试

> #### 注意
> - 由于增加了 Python 支持，因此直接使用 Python 进行串口通信的验证
> - 测试平台为 Ubuntu 22.04，使用 `socat` 工具创建虚拟串口

创建虚拟串口

```bash
socat -d -d pty,raw,echo=0 pty,raw,echo=0
```

提示

```
2024/11/24 17:38:29 socat[373061] N PTY is /dev/pts/6
2024/11/24 17:38:29 socat[373061] N PTY is /dev/pts/7
2024/11/24 17:38:29 socat[373061] N starting data transfer loop with FDs [5,5] and [7,7]
```

`com1.py` 向串口写数据

```python
#!/usr/bin/python3

import rm

com1 = rm.SerialPort("/dev/pts/6")

res = com1.write("123abc")
if not res:
    print("write error")
    exit(1)
```

`com2.py` 从串口读数据

```python
#!/usr/bin/python3

import rm

mode = rm.SerialPortMode()
mode.read_mode = rm.SerialReadMode.BLOCK
com2 = rm.SerialPort("/dev/pts/7", mode)

res, data = com2.read()
if not res:
    print("read error")
    exit(1)

print("val = {}".format(data))
```

先运行 `com2.py` 再运行 `com1.py`，运行结果如下：

```bash
./com2.py 
# info - Opening the serial port: /dev/pts/7
# val = 123abc

./com1.py 
# info - Opening the serial port: /dev/pts/6
```
