### PR TITLE
✨ 增加海康机器人 RS-232 光源控制库，目前仅支持 LEAD 型号

### DIFF
--- a/doc/tutorials/modules/tools/light.md
+++ b/doc/tutorials/modules/tools/light.md
@@ -30,7 +30,7 @@ int main()
     // 创建光源控制器对象
     auto light_controller = rm::OPTLightController();
     // 连接光源控制器
-    auto lipc = rm::LightIpConfig{"192.168.1.100", "192.168.1.1", "255.255.255.0"};
+    auto lipc = rm::OPTLightIpConfig{"192.168.1.100", "192.168.1.1", "255.255.255.0"};
     light_controller.connect(lipc);
     // 打开指定的通道
     light_controller.openChannels({1});
@@ -51,7 +51,7 @@ import rm
 # 创建光源控制器对象
 light_controller = rm.OPTLightController()
 # 连接光源控制器
-cfg = rm.LightIpConfig()
+cfg = rm.OPTLightIpConfig()
 cfg.ip = "192.168.1.100"
 cfg.gateway = "192.168.1.1"
 cfg.netmask = "255.255.255.0"

--- a/modules/camera/include/rmvl/camera/camutils.hpp
+++ b/modules/camera/include/rmvl/camera/camutils.hpp
@@ -1,7 +1,7 @@
 /**
  * @file camutils.hpp
  * @author zhaoxi (535394140@qq.com)
- * @brief
+ * @brief 相机基本配置信息
  * @version 1.0
  * @date 2022-09-30
  *

--- a/modules/light/CMakeLists.txt
+++ b/modules/light/CMakeLists.txt
@@ -1,3 +1,7 @@
+# ----------------------------------------------------------------------------
+#  Light control module
+# ----------------------------------------------------------------------------
+# opt_light_control
 find_package(OPTLightCtrl QUIET)
 rmvl_update_build(opt_light_control OPTLightCtrl_FOUND)
 
@@ -11,14 +15,36 @@ rmvl_link_libraries(
   PRIVATE optlc
 )
 
+# hik_light_control
+rmvl_generate_para(
+  hik_light_control
+  MODULE light
+)
+
+rmvl_add_module(
+  hik_light_control
+  DEPENDS core
+) 
+
+# ----------------------------------------------------------------------------
+#  Parameters module for 'light'
+# ----------------------------------------------------------------------------
+rmvl_generate_module_para(light)
+
 # ----------------------------------------------------------------------------
 #  Build Python bindings
 # ----------------------------------------------------------------------------
 if(BUILD_PYTHON)
-  foreach(m opt)
+  set(light_inc rmvl/light/lightutils.hpp)
+  foreach(m opt hik)
     if(BUILD_rmvl_${m}_light_control)
       list(APPEND light_inc rmvl/light/${m}_light_control.h)
       list(APPEND light_dep ${m}_light_control)
+    endif()
+  endforeach()
+  foreach(m hik)
+    if(BUILD_rmvl_${m}_light_control)
+      list(APPEND light_inc rmvlpara/light/${m}_light_control.h)
     endif()
   endforeach()
   rmvl_generate_python(light

--- a/modules/light/include/rmvl/light.hpp
+++ b/modules/light/include/rmvl/light.hpp
@@ -22,3 +22,7 @@
 #ifdef HAVE_RMVL_OPT_LIGHT_CONTROL
 #include "light/opt_light_control.h"
 #endif // HAVE_RMVL_OPT_LIGHT_CONTROL
+
+#ifdef HAVE_RMVL_HIK_LIGHT_CONTROL
+#include "light/hik_light_control.h"
+#endif // HAVE_RMVL_HIK_LIGHT_CONTROL

--- a/modules/light/include/rmvl/light/hik_light_control.h
+++ b/modules/light/include/rmvl/light/hik_light_control.h
@@ -1,0 +1,90 @@
+/**
+ * @file hik_light_control.h
+ * @author zhaoxi (535394140@qq.com)
+ * @brief 海康机器人 RS-232 光源控制库
+ * @version 1.0
+ * @date 2024-11-25
+ *
+ * @copyright Copyright 2024 (c), zhaoxi
+ *
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "lightutils.hpp"
+
+namespace rm
+{
+
+//! @addtogroup hik_light_control
+//! @{
+
+//! 海康机器人光源控制器产品 ID
+enum class HikProductID
+{
+    LEAD, //!< 点光源控制器
+};
+
+//! 海康机器人光源控制器
+class RMVL_EXPORTS_W HikLightController
+{
+    RMVL_IMPL;
+
+public:
+    /**
+     * @brief 构造海康机器人光源控制器对象，并使用建立连接
+     *
+     * @param[in] cfg 光源控制器配置
+     * @param[in] pid 光源控制器产品 ID
+     * @param[in] id 光源控制器唯一标识，目前只支持串口设备名称
+     */
+    RMVL_W HikLightController(const LightConfig &cfg, HikProductID pid, std::string_view id);
+
+    //! @cond
+    HikLightController(const HikLightController &) = delete;
+    HikLightController(HikLightController &&) = default;
+    HikLightController &operator=(const HikLightController &) = delete;
+    HikLightController &operator=(HikLightController &&) = default;
+    //! @endcond
+
+    //! 光源控制器是否打开
+    RMVL_W bool isOpened() const;
+
+    /**
+     * @brief 设置为常亮模式，即打开全部通道
+     *
+     * @return 指定通道是否打开成功？
+     */
+    RMVL_W bool open();
+
+    /**
+     * @brief 设置为常灭模式，即关闭全部通道
+     *
+     * @return 指定通道是否关闭成功？
+     */
+    RMVL_W bool close();
+
+    /**
+     * @brief 获取指定通道的光源亮度
+     *
+     * @param[in] chn 指定通道，范围: `1 ~ 8`
+     * @return 若读取成功，返回 \f$[0, 255]\f$ 的值，否则返回 \f$-1\f$
+     */
+    RMVL_W int get(int chn) const;
+
+    /**
+     * @brief 设置指定通道的光源亮度
+     *
+     * @param[in] chn 指定通道，范围: `1 ~ 8`
+     * @param[in] val 指定通道的光源亮度
+     * @return 是否设置成功？
+     */
+    RMVL_W bool set(int chn, int val);
+};
+
+//! @} hik_light_control
+
+} // namespace rm

--- a/modules/light/include/rmvl/light/lightutils.hpp
+++ b/modules/light/include/rmvl/light/lightutils.hpp
@@ -1,0 +1,33 @@
+/**
+ * @file lightutils.hpp
+ * @author zhaoxi (535394140@qq.com)
+ * @brief 光源控制基本配置信息
+ * @version 1.0
+ * @date 2024-11-25
+ *
+ * @copyright Copyright 2024 (c), zhaoxi
+ *
+ */
+
+#pragma once
+
+#include "rmvl/core/util.hpp"
+
+namespace rm
+{
+
+//! 光源控制器通信模式
+enum class LightHandleMode
+{
+    IP,     //!< IP 地址
+    Key,    //!< 设备序列号
+    Serial, //!< 串口通信
+};
+
+//! 光源控制器初始化配置模式
+struct RMVL_EXPORTS_W_AG LightConfig
+{
+    RMVL_W_RW LightHandleMode handle_mode{}; //!< 通信模式
+};
+
+} // namespace rm

--- a/modules/light/include/rmvl/light/opt_light_control.h
+++ b/modules/light/include/rmvl/light/opt_light_control.h
@@ -1,7 +1,7 @@
 /**
  * @file opt_light_control.h
  * @author zhaoxi (535394140@qq.com)
- * @brief
+ * @brief OPT 奥普特 GigE 光源控制库
  * @version 1.0
  * @date 2023-10-04
  *
@@ -11,10 +11,10 @@
 
 #pragma once
 
-#include <string>
+#include <memory>
 #include <vector>
 
-#include "rmvl/core/rmvldef.hpp"
+#include "lightutils.hpp"
 
 namespace rm
 {
@@ -22,49 +22,29 @@ namespace rm
 //! @addtogroup opt_light_control
 //! @{
 
-//! OPT 光源控制器 IP 配置信息
-struct RMVL_EXPORTS_W_AG LightIpConfig
-{
-    RMVL_W_RW std::string ip;              //!< IP 地址
-    RMVL_W_RW std::string subnet_mask;     //!< 子网掩码
-    RMVL_W_RW std::string default_gateway; //!< 默认网关
-};
-
 //! OPT 奥普特光源控制器
 class RMVL_EXPORTS_W OPTLightController
 {
-    using OPTController_StatusCode = long;
+    RMVL_IMPL;
 
 public:
-    //! 构造新 OPTLightController 对象
-    RMVL_W OPTLightController() = default;
-    //! 禁止从 OPTLightController 对象复制构造
+    /**
+     * @brief 构造奥普特光源控制器对象，并使用建立连接
+     *
+     * @param[in] cfg 光源控制器配置
+     * @param[in] id 光源控制器唯一标识，可以是 IP 地址或者唯一序列号
+     */
+    RMVL_W OPTLightController(const LightConfig &cfg, std::string_view id);
+
+    //! @cond
     OPTLightController(const OPTLightController &) = delete;
-    //! 移动 OPTLightController 对象
-    OPTLightController(OPTLightController &&obj) = default;
+    OPTLightController(OPTLightController &&) = default;
+    OPTLightController &operator=(const OPTLightController &) = delete;
+    OPTLightController &operator=(OPTLightController &&) = default;
+    //! @endcond
 
-    ~OPTLightController() { disconnect(); }
-
-    /**
-     * @brief 使用 IP 地址创建 EtherNet 以太网连接
-     *
-     * @param[in] ip_config IP 配置信息
-     * @return 连接是否成功建立？
-     */
-    RMVL_W bool connect(const LightIpConfig &ip_config);
-
-    /**
-     * @brief 使用设备序列号创建 EtherNet 以太网连接
-     *
-     * @param[in] SN 设备序列号
-     * @return 连接是否成功建立？
-     */
-    RMVL_W bool connect(std::string_view SN);
-
-    /**
-     * @brief 断开已存在网口的连接
-     */
-    RMVL_W bool disconnect();
+    //! 光源控制器是否打开
+    RMVL_W bool isOpened() const noexcept;
 
     /**
      * @brief 打开指定通道
@@ -72,14 +52,14 @@ public:
      * @param[in] channels 要打开的通道的索引组成的 `std::vector` ，范围: [1 ~ 32]（十进制格式）
      * @return 指定通道是否打开成功？
      */
-    RMVL_W bool openChannels(const std::vector<int> &channels);
+    RMVL_W bool open(const std::vector<int> &channels) noexcept;
 
     /**
      * @brief 打开全部通道
      *
      * @return 指定通道是否打开成功？
      */
-    RMVL_W bool openAllChannels();
+    RMVL_W bool open() noexcept;
 
     /**
      * @brief 关闭指定通道
@@ -87,14 +67,14 @@ public:
      * @param[in] channels 要关闭的通道的索引组成的 `std::vector` ，范围: [1 ~ 32]（十进制格式）
      * @return 指定通道是否关闭成功？
      */
-    RMVL_W bool closeChannels(const std::vector<int> &channels);
+    RMVL_W bool close(const std::vector<int> &channels) noexcept;
 
     /**
      * @brief 关闭全部通道
      *
      * @return 指定通道是否关闭成功？
      */
-    RMVL_W bool closeAllChannels();
+    RMVL_W bool close() noexcept;
 
     /**
      * @brief 获取指定通道的光源亮度
@@ -102,7 +82,7 @@ public:
      * @param[in] channel 指定通道
      * @return 若读取成功，返回 \f$[0, 255]\f$ 的值，否则返回 \f$-1\f$
      */
-    RMVL_W int getIntensity(int channel) const;
+    RMVL_W int getIntensity(int channel) const noexcept;
 
     /**
      * @brief 设置指定通道的光源亮度
@@ -111,20 +91,16 @@ public:
      * @param[in] intensity 指定通道的光源亮度
      * @return 是否设置成功？
      */
-    RMVL_W bool setIntensity(int channel, int intensity);
+    RMVL_W bool setIntensity(int channel, int intensity) noexcept;
 
     /**
      * @brief 光源控制器软触发指定通道
      *
-     * @param[in] channel 指定通道
+     * @param[in] channel 指定通道，范围: [1 ~ 8]（十进制格式）
      * @param[in] time 触发时间，单位: 10ms
      * @return 是否成功触发？
      */
-    RMVL_W bool trigger(int channel, int time) const;
-
-private:
-    bool _init{};        //!< 初始化标志位
-    long long _handle{}; //!< 光源控制器句柄
+    RMVL_W bool trigger(int channel, int time) const noexcept;
 };
 
 //! @} opt_light_control

--- a/modules/light/param/hik_light_control.para
+++ b/modules/light/param/hik_light_control.para
@@ -1,0 +1,1 @@
+uint32_t DELAY_AFTER_WRITE = 10 # 串口写入后的延时时间，单位 ms

--- a/modules/light/src/hik_light_control/hik_light_impl.hpp
+++ b/modules/light/src/hik_light_control/hik_light_impl.hpp
@@ -1,0 +1,50 @@
+/**
+ * @file hik_light_impl.hpp
+ * @author zhaoxi (535394140@qq.com)
+ * @brief 海康机器人 RS-232 光源控制库实现
+ * @version 1.0
+ * @date 2024-11-25
+ *
+ * @copyright Copyright 2024 (c), zhaoxi
+ *
+ */
+
+#pragma once
+
+#include "rmvl/light/hik_light_control.h"
+
+#include "rmvl/core/io.hpp"
+
+namespace rm
+{
+
+//! 海康机器人光源控制器
+class HikLightController::Impl
+{
+public:
+    Impl(const LightConfig &cfg, HikProductID pid, std::string_view id);
+
+    Impl(const Impl &) = delete;
+    Impl(Impl &&) = default;
+
+    //! 光源控制器是否打开
+    inline bool isOpened() const { return _sp != nullptr && _sp->isOpened(); }
+
+    //! 设置为常亮模式，即打开全部通道
+    bool open();
+
+    //! 设置为常灭模式，即关闭全部通道
+    bool close();
+
+    //! 获取指定通道的光源亮度
+    int get(int chn) const;
+
+    //! 设置指定通道的光源亮度
+    bool set(int chn, int val);
+
+private:
+    HikProductID _pid{};               //!< 光源控制器产品 ID
+    std::unique_ptr<SerialPort> _sp{}; //!< 串口对象
+};
+
+} // namespace rm

--- a/modules/light/src/hik_light_control/light_control.cpp
+++ b/modules/light/src/hik_light_control/light_control.cpp
@@ -1,0 +1,150 @@
+#include <thread>
+
+#include "hik_light_impl.hpp"
+
+#include "rmvlpara/light/hik_light_control.h"
+
+namespace rm
+{
+
+RMVL_IMPL_DEF(HikLightController)
+
+HikLightController::HikLightController(const LightConfig &cfg, HikProductID pid, std::string_view id) : _impl(new Impl(cfg, pid, id)) {}
+bool HikLightController::isOpened() const { return _impl->isOpened(); }
+bool HikLightController::open() { return _impl->open(); }
+bool HikLightController::close() { return _impl->close(); }
+int HikLightController::get(int chn) const { return _impl->get(chn); }
+bool HikLightController::set(int chn, int val) { return _impl->set(chn, val); }
+
+static std::unique_ptr<SerialPort> lead_create(std::string_view id)
+{
+    SerialPortMode mode{};
+    mode.baud_rate = BaudRate::BR_19200;
+    mode.read_mode = SerialReadMode::BLOCK;
+    return std::make_unique<SerialPort>(id, mode);
+}
+
+static bool lead_open(SerialPort &sp)
+{
+    if (!sp.write("SH#"))
+        return false;
+    std::this_thread::sleep_for(std::chrono::milliseconds(para::hik_light_control_param.DELAY_AFTER_WRITE));
+    std::string buf;
+    if (!sp.read(buf))
+        return false;
+    return buf == "H";
+}
+
+static bool lead_close(SerialPort &sp)
+{
+    if (!sp.write("SL#"))
+        return false;
+    std::this_thread::sleep_for(std::chrono::milliseconds(para::hik_light_control_param.DELAY_AFTER_WRITE));
+    std::string buf;
+    if (!sp.read(buf))
+        return false;
+    return buf == "L";
+}
+
+using namespace std::string_literals;
+constexpr const char HIK_CHN_STR[] = "ABCDEFGH";
+
+static int lead_get(SerialPort &sp, int chn)
+{
+    RMVL_Assert(chn > 0 && chn <= 8);
+    if (!sp.write("S"s + HIK_CHN_STR[chn - 1] + "#"))
+        return -1;
+    std::string buf;
+    std::this_thread::sleep_for(std::chrono::milliseconds(para::hik_light_control_param.DELAY_AFTER_WRITE));
+    if (!sp.read(buf))
+        return -1;
+    if (buf == "NG")
+        return -1;
+    return std::stoi(std::string(buf.begin() + 1, buf.end()));
+}
+
+static bool lead_set(SerialPort &sp, int chn, int val)
+{
+    RMVL_Assert(chn > 0 && chn <= 8 && val >= 0 && val <= 255);
+    char ch = HIK_CHN_STR[chn - 1];
+    char command[8]{};
+    snprintf(command, sizeof(command), "S%c%04d#", HIK_CHN_STR[chn - 1], val);
+
+    if (!sp.write(command))
+        return false;
+    std::this_thread::sleep_for(std::chrono::milliseconds(para::hik_light_control_param.DELAY_AFTER_WRITE));
+    std::string buf;
+    if (!sp.read(buf))
+        return false;
+    return buf == std::string(1, ch);
+}
+
+HikLightController::Impl::Impl(const LightConfig &cfg, HikProductID pid, std::string_view id) : _pid(pid)
+{
+    if (cfg.handle_mode == LightHandleMode::Serial)
+    {
+        switch (pid)
+        {
+        case HikProductID::LEAD:
+            _sp = lead_create(id);
+            break;
+        default:
+            break;
+        }
+    }
+    else
+    {
+        RMVL_Error(RMVL_StsBadArg, "Unsupported handle mode");
+    }
+}
+
+bool HikLightController::Impl::open()
+{
+    RMVL_DbgAssert(isOpened());
+    switch (_pid)
+    {
+    case HikProductID::LEAD:
+        return lead_open(*_sp);
+    default:
+        return false;
+    }
+}
+
+bool HikLightController::Impl::close()
+{
+    RMVL_DbgAssert(isOpened());
+    switch (_pid)
+    {
+    case HikProductID::LEAD:
+        return lead_close(*_sp);
+    default:
+        return false;
+    }
+}
+
+int HikLightController::Impl::get(int chn) const
+{
+    RMVL_DbgAssert(isOpened());
+
+    switch (_pid)
+    {
+    case HikProductID::LEAD:
+        return lead_get(*_sp, chn);
+    default:
+        return -1;
+    }
+}
+
+bool HikLightController::Impl::set(int chn, int val)
+{
+    RMVL_DbgAssert(isOpened());
+    switch (_pid)
+    {
+    case HikProductID::LEAD:
+        return lead_set(*_sp, chn, val);
+    default:
+        return false;
+    }
+}
+
+} // namespace rm

--- a/modules/light/src/opt_light_control/light_control.cpp
+++ b/modules/light/src/opt_light_control/light_control.cpp
@@ -1,63 +1,68 @@
-/**
- * @file light_control.cpp
- * @author 赵曦 (535394140@qq.com)
- * @brief
- * @version 1.0
- * @date 2022-09-27
- *
- * @copyright Copyright (c) 2023, zhaoxi
- *
- */
-
 #include <thread>
 
 #include <OPTController.h>
 #include <OPTErrorCode.h>
 
-#include "rmvl/light/opt_light_control.h"
+#include "opt_light_impl.hpp"
 
-bool rm::OPTLightController::connect(const LightIpConfig &ip_config)
+namespace rm
+{
+
+RMVL_IMPL_DEF(OPTLightController)
+
+OPTLightController::OPTLightController(const LightConfig &cfg, std::string_view id) : _impl(new Impl(cfg, id)) {}
+bool OPTLightController::isOpened() const noexcept { return _impl->isOpened(); }
+bool OPTLightController::open(const std::vector<int> &channels) noexcept { return _impl->open(channels); }
+bool OPTLightController::open() noexcept { return _impl->open(); }
+bool OPTLightController::close(const std::vector<int> &channels) noexcept { return _impl->close(channels); }
+bool OPTLightController::close() noexcept { return _impl->close(); }
+int OPTLightController::getIntensity(int channel) const noexcept { return _impl->getIntensity(channel); }
+bool OPTLightController::setIntensity(int channel, int intensity) noexcept { return _impl->setIntensity(channel, intensity); }
+bool OPTLightController::trigger(int channel, int time) const noexcept { return _impl->trigger(channel, time); }
+
+OPTLightController::Impl::Impl(const LightConfig &cfg, std::string_view id)
 {
     if (_init)
         disconnect();
-    _init = true;
-    return OPTController_CreateEtheConnectionByIP(const_cast<char *>(ip_config.ip.c_str()), &_handle) == OPT_SUCCEED;
-}
-
-bool rm::OPTLightController::connect(std::string_view SN)
-{
-    using namespace std::chrono_literals;
-    if (_init)
-        disconnect();
-    _init = true;
-    if (OPTController_CreateEtheConnectionBySN(const_cast<char *>(SN.data()), &_handle) == OPT_SUCCEED)
+    switch (cfg.handle_mode)
     {
-        std::this_thread::sleep_for(1ms);
-        return true;
+    case LightHandleMode::IP:
+        _init = (OPTController_CreateEtheConnectionByIP(const_cast<char *>(id.data()), &_handle) == OPT_SUCCEED);
+        break;
+    case LightHandleMode::Key:
+        if (OPTController_CreateEtheConnectionBySN(const_cast<char *>(id.data()), &_handle) == OPT_SUCCEED)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            _init = true;
+        }
+        break;
+    default:
+        RMVL_Error(RMVL_StsBadArg, "Unknown handle mode.");
     }
-    else
-        return false;
 }
 
-bool rm::OPTLightController::disconnect()
+bool OPTLightController::Impl::disconnect() noexcept
 {
     if (_init)
     {
-        closeAllChannels();
+        close();
         _init = false;
         return OPTController_DestroyEtheConnection(_handle) == OPT_SUCCEED;
     }
     return false;
 }
 
-bool rm::OPTLightController::openChannels(const std::vector<int> &channels)
+bool OPTLightController::Impl::open(const std::vector<int> &channels) noexcept
 {
     return OPTController_TurnOnMultiChannel(_handle, const_cast<int *>(channels.data()), static_cast<int>(channels.size())) == OPT_SUCCEED;
 }
 
-bool rm::OPTLightController::openAllChannels() { return OPTController_TurnOnChannel(_handle, 0) == OPT_SUCCEED; }
+bool OPTLightController::Impl::open() noexcept
+{
+    return OPTController_TurnOnChannel(_handle, 0) == OPT_SUCCEED;
+}
 
-bool rm::OPTLightController::closeChannels(const std::vector<int> &channels)
+bool OPTLightController::Impl::close(const std::vector<int> &channels) noexcept
 {
     std::vector<IntensityItem> intensities(channels.size());
     for (size_t i = 0; i < channels.size(); ++i)
@@ -67,21 +72,26 @@ bool rm::OPTLightController::closeChannels(const std::vector<int> &channels)
                                              static_cast<int>(channels.size())) == OPT_SUCCEED;
 }
 
-bool rm::OPTLightController::closeAllChannels()
+bool OPTLightController::Impl::close() noexcept
 {
     OPTController_SetIntensity(_handle, 0, 0);
     return OPTController_TurnOffChannel(_handle, 0) == OPT_SUCCEED;
 }
 
-int rm::OPTLightController::getIntensity(int channel) const
+int OPTLightController::Impl::getIntensity(int channel) const noexcept
 {
     int intensity;
     return OPTController_ReadIntensity(_handle, channel, &intensity) == OPT_SUCCEED ? intensity : -1;
 }
 
-bool rm::OPTLightController::setIntensity(int channel, int intensity)
+bool OPTLightController::Impl::setIntensity(int channel, int intensity) noexcept
 {
     return OPTController_SetIntensity(_handle, channel, intensity) == OPT_SUCCEED;
 }
 
-bool rm::OPTLightController::trigger(int channel, int time) const { return OPTController_SoftwareTrigger(_handle, channel, time) == OPT_SUCCEED; }
+bool OPTLightController::Impl::trigger(int channel, int time) const noexcept
+{
+    return OPTController_SoftwareTrigger(_handle, channel, time) == OPT_SUCCEED;
+}
+
+} // namespace rm

--- a/modules/light/src/opt_light_control/opt_light_impl.hpp
+++ b/modules/light/src/opt_light_control/opt_light_impl.hpp
@@ -1,0 +1,61 @@
+/**
+ * @file opt_impl.hpp
+ * @author zhaoxi (535394140@qq.com)
+ * @brief OPT 奥普特光源控制库实现
+ * @version 1.0
+ * @date 2024-11-25
+ *
+ * @copyright Copyright 2024 (c), zhaoxi
+ *
+ */
+
+#pragma once
+
+#include "rmvl/light/opt_light_control.h"
+
+namespace rm
+{
+
+//! OPT 奥普特光源控制器
+class OPTLightController::Impl
+{
+public:
+    Impl(const LightConfig &cfg, std::string_view id);
+
+    Impl(const Impl &) = delete;
+    Impl(Impl &&) = default;
+
+    ~Impl();
+
+    //! 光源控制器是否打开
+    inline bool isOpened() const noexcept { return _init; }
+
+    //! 打开指定通道
+    bool open(const std::vector<int> &channels) noexcept;
+
+    //! 打开全部通道
+    bool open() noexcept;
+
+    //! 关闭指定通道
+    bool close(const std::vector<int> &channels) noexcept;
+
+    //! 关闭全部通道
+    bool close() noexcept;
+
+    //! 获取指定通道的光源亮度
+    int getIntensity(int channel) const noexcept;
+
+    //! 设置指定通道的光源亮度
+    bool setIntensity(int channel, int intensity) noexcept;
+
+    //! 光源控制器软触发指定通道
+    bool trigger(int channel, int time) const noexcept;
+
+private:
+    bool disconnect() noexcept;
+
+    bool _init{};        //!< 初始化标志位
+    long long _handle{}; //!< 光源控制器句柄
+};
+
+} // namespace rm


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [ ] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 增加海康机器人 RS-232 光源控制库 `hik_light_control`

### 本地测试

C++ 简易测试代码

```cpp
#include <rmvl/light/hik_light_control.h>

int main()
{
    rm::LightConfig cfg{};
    cfg.handle_mode = rm::LightHandleMode::Serial;
    rm::HikLightController lc(cfg, rm::HikProductID::LEAD, "/dev/ttyUSB0");

    if (!lc.set(1, 50))
        ERROR_("set failed");
}
```

Python 简易测试代码

```python
import rm

cfg = rm.LightConfig()
cfg.handle_mode = rm.LightHandleMode.Serial
lc = rm.HikLightController(cfg, rm.HikProductID.LEAD, "/dev/ttyUSB0")

if not lc.set(1, 50)
    print("set failed");
```
