### PR TITLE
增加 BUILD_WORLD 编译选项，以包装成单独的动态、静态库

### DIFF
--- a/3rdparty/apriltag/CMakeLists.txt
+++ b/3rdparty/apriltag/CMakeLists.txt
@@ -32,6 +32,7 @@ target_include_directories(
 set_target_properties(
   apriltag PROPERTIES
   OUTPUT_NAME apriltag
+  DEBUG_POSTFIX "${RMVL_DEBUG_POSTFIX}"
   ARCHIVE_OUTPUT_DIRECTORY ${3P_LIBRARY_OUTPUT_PATH}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ include(cmake/RMVLUtils.cmake)
 # ----------------------------------------------------------------------------
 #  Include necessary CMake modules
 # ----------------------------------------------------------------------------
-include_directories(${CMAKE_BINARY_DIR})
+include_directories(${PROJECT_BINARY_DIR})
 
 # RMVL version number from sources
 include(cmake/RMVLVersion.cmake)

--- a/cmake/FindGalaxySDK.cmake
+++ b/cmake/FindGalaxySDK.cmake
@@ -41,7 +41,7 @@ if(UNIX)
   )
 
   if(NOT TARGET galaxysdk)
-    add_library(galaxysdk SHARED IMPORTED)
+    add_library(galaxysdk SHARED IMPORTED GLOBAL)
     set_target_properties(galaxysdk PROPERTIES
       IMPORTED_LOCATION "${GalaxySDK_LIB}"
       INTERFACE_INCLUDE_DIRECTORIES "${GalaxySDK_INCLUDE_DIR}"
@@ -68,7 +68,7 @@ elseif(WIN32)
   )
 
   if(NOT TARGET galaxysdk)
-    add_library(galaxysdk SHARED IMPORTED)
+    add_library(galaxysdk SHARED IMPORTED GLOBAL)
     set_target_properties(galaxysdk PROPERTIES
       IMPORTED_IMPLIB "${GalaxySDK_LIB}"
       IMPORTED_LOCATION "${GalaxySDK_DLL}"

--- a/cmake/FindHikSDK.cmake
+++ b/cmake/FindHikSDK.cmake
@@ -40,7 +40,7 @@ if(UNIX)
   )
 
   if(NOT TARGET hiksdk)
-    add_library(hiksdk SHARED IMPORTED)
+    add_library(hiksdk SHARED IMPORTED GLOBAL)
     set_target_properties(hiksdk PROPERTIES
       IMPORTED_LOCATION "${HikSDK_LIB}"
       INTERFACE_INCLUDE_DIRECTORIES "${HikSDK_INCLUDE_DIR}"
@@ -79,7 +79,7 @@ elseif(WIN32)
   )
 
   if(NOT TARGET hiksdk)
-    add_library(hiksdk SHARED IMPORTED)
+    add_library(hiksdk SHARED IMPORTED GLOBAL)
     set_target_properties(hiksdk PROPERTIES
       IMPORTED_IMPLIB "${HikSDK_LIB}"
       IMPORTED_LOCATION "${HikSDK_DLL}"

--- a/cmake/FindMvSDK.cmake
+++ b/cmake/FindMvSDK.cmake
@@ -15,7 +15,7 @@ if(UNIX)
   )
 
   if(NOT TARGET mvsdk)
-    add_library(mvsdk SHARED IMPORTED)
+    add_library(mvsdk SHARED IMPORTED GLOBAL)
     set_target_properties(mvsdk PROPERTIES
       IMPORTED_LOCATION "${MvSDK_LIB}"
       INTERFACE_INCLUDE_DIRECTORIES "${MvSDK_INCLUDE_DIR}"
@@ -57,7 +57,7 @@ elseif(WIN32)
   )
 
   if(NOT TARGET mvsdk)
-    add_library(mvsdk SHARED IMPORTED)
+    add_library(mvsdk SHARED IMPORTED GLOBAL)
     set_target_properties(mvsdk PROPERTIES
       IMPORTED_IMPLIB "${MvSDK_LIB}"
       IMPORTED_LOCATION "${MvSDK_DLL}"

--- a/cmake/FindOPTCameraSDK.cmake
+++ b/cmake/FindOPTCameraSDK.cmake
@@ -17,7 +17,7 @@ find_library(
 )
 
 if(NOT TARGET optcamsdk)
-  add_library(optcamsdk SHARED IMPORTED)
+  add_library(optcamsdk SHARED IMPORTED GLOBAL)
   set_target_properties(optcamsdk PROPERTIES
     IMPORTED_LOCATION "${OPTCameraSDK_LIB}"
     INTERFACE_INCLUDE_DIRECTORIES "${OPTCameraSDK_INCLUDE_DIR}"

--- a/cmake/FindOPTLightCtrl.cmake
+++ b/cmake/FindOPTLightCtrl.cmake
@@ -17,7 +17,7 @@ find_library(
 )
 
 if(NOT TARGET optlc)
-  add_library(optlc SHARED IMPORTED)
+  add_library(optlc SHARED IMPORTED GLOBAL)
   set_target_properties(optlc PROPERTIES
     IMPORTED_LOCATION "${OPTLightCtrl_LIB}"
     INTERFACE_INCLUDE_DIRECTORIES "${OPTLightCtrl_INCLUDE_DIR}"

--- a/cmake/FindOrt.cmake
+++ b/cmake/FindOrt.cmake
@@ -32,7 +32,7 @@ find_library(
 #  create imported target: onnxruntime
 # ------------------------------------------------------------------------------
 if(NOT TARGET onnxruntime)
-  add_library(onnxruntime SHARED IMPORTED)
+  add_library(onnxruntime SHARED IMPORTED GLOBAL)
   set_target_properties(onnxruntime PROPERTIES
     IMPORTED_LOCATION "${Ort_LIB}"
     INTERFACE_INCLUDE_DIRECTORIES "${Ort_INCLUDE_DIR}"

--- a/cmake/RMVLCompilerOptions.cmake
+++ b/cmake/RMVLCompilerOptions.cmake
@@ -104,7 +104,7 @@ set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 set(3P_LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/3rdparty/lib)
 
 # ----------------------------------------------------------------------------
-#   Build options
+#   Build options and configurations
 # ----------------------------------------------------------------------------
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(ENABLE_PIC "Generate position independent code (necessary for shared libraries)" ON)
@@ -134,6 +134,20 @@ if(ENABLE_LTO)
       set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LTCG")
     endif()
   endif()
+endif()
+
+if(WIN32)
+  # postfix of DLLs
+  set(RMVL_LIBVERSION_SUFFIX "${RMVL_VERSION_MAJOR}${RMVL_VERSION_MINOR}${RMVL_VERSION_PATCH}" CACHE INTERNAL "RMVL library version suffix")
+  set(RMVL_DEBUG_POSTFIX "d" CACHE INTERNAL "RMVL debug postfix")
+else()
+  # postfix of *.so
+  set(RMVL_LIBVERSION_SUFFIX "")
+  set(RMVL_DEBUG_POSTFIX "")
+endif()
+
+if(DEFINED CMAKE_DEBUG_POSTFIX)
+  set(RMVL_DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}" CACHE INTERNAL "RMVL debug postfix")
 endif()
 
 # ----------------------------------------------------------------------------
@@ -310,6 +324,19 @@ _rmvl_set_build_with_3rdparty(open62541 OFF)
 # ----------------------------------------------------------------------------
 #   Module and other options
 # ----------------------------------------------------------------------------
+option(BUILD_WORLD "Build all modules as a single library" OFF)
+if(BUILD_WORLD)
+  if(BUILD_SHARED_LIBS)
+    add_library(rmvl_world SHARED)
+    set_target_properties(
+      rmvl_world PROPERTIES
+      DEFINE_SYMBOL RMVLAPI_EXPORTS
+    )
+  else()
+    add_library(rmvl_world STATIC)
+  endif()
+endif()
+
 option(BUILD_EXTRA "Build extra modules containing 4 data components and 4 function modules" OFF)
 if(NOT WITH_OPENCV)
   unset(BUILD_EXTRA CACHE)

--- a/cmake/RMVLGenConfig.cmake
+++ b/cmake/RMVLGenConfig.cmake
@@ -2,8 +2,12 @@
 #  Installation for CMake Module:  RMVLConfig.cmake
 #  Part 1/3: Prepare module list
 #  Part 2/3: Generate RMVLConfig.cmake
-#  Part 3/3: Make install
+#  Part 3/3: Generate install target
 # --------------------------------------------------------------------------------------------
+
+if(BUILD_WORLD)
+  rmvl_add_world()
+endif()
 
 set(cmake_dir "${CMAKE_SOURCE_DIR}/cmake")
 set(config_dir "${CMAKE_BINARY_DIR}/config-install")
@@ -12,7 +16,11 @@ set(template_dir "${cmake_dir}/templates")
 # --------------------------------------------------------------------------------------------
 #  Part 1/3: Prepare module list
 # --------------------------------------------------------------------------------------------
-set(RMVL_MODULES_CONFIGCMAKE ${RMVL_MODULES_BUILD})
+if(BUILD_WORLD)
+  set(RMVL_MODULES_CONFIGCMAKE world)
+else()
+  set(RMVL_MODULES_CONFIGCMAKE ${RMVL_MODULES_BUILD})
+endif()
 
 set(RMVL_MODULES_IMPORTED_CONFIGCMAKE "")
 # --------------------------------------------------------------------

--- a/cmake/RMVLGenPython.cmake
+++ b/cmake/RMVLGenPython.cmake
@@ -102,9 +102,15 @@ function(rmvl_generate_python _name)
     DEPENDS ${RMVL_PYBIND_NAME}
   )
 
-  foreach(dep ${PY_DEPENDS})
-    target_link_libraries(${RMVL_PYBIND_NAME} PUBLIC rmvl_${dep})
-  endforeach()
+  if(PY_DEPENDS)
+    if(BUILD_WORLD)
+      target_link_libraries(${RMVL_PYBIND_NAME} PUBLIC rmvl_world)
+    else()
+      foreach(dep ${PY_DEPENDS})
+        target_link_libraries(${RMVL_PYBIND_NAME} PUBLIC rmvl_${dep})
+      endforeach()
+    endif()
+  endif()
 
   set_target_properties(
     ${RMVL_PYBIND_NAME} PROPERTIES

--- a/cmake/RMVLUtils.cmake
+++ b/cmake/RMVLUtils.cmake
@@ -119,12 +119,10 @@ macro(rmvl_finalize_status)
   unset(_content)
   unset(RMVL_BUILD_INFO_STR CACHE)
 
-  if(DEFINED RMVL_MODULE_rmvl_core_BINARY_DIR)
-    execute_process(
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${RMVL_BUILD_INFO_FILE}" "${RMVL_MODULE_rmvl_core_BINARY_DIR}/version_string.inc"
-      OUTPUT_QUIET
-    )
-  endif()
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${RMVL_BUILD_INFO_FILE}" "${PROJECT_BINARY_DIR}/version_string.inc"
+    OUTPUT_QUIET
+  )
 endmacro()
 
 # ----------------------------------------------------------------------------

--- a/extra/detector/CMakeLists.txt
+++ b/extra/detector/CMakeLists.txt
@@ -39,20 +39,16 @@ rmvl_add_module(
 )
 
 # tag_detector
+rmvl_update_build(tag_detector WITH_APRILTAG)
 rmvl_generate_para(
   tag_detector
   MODULE detector
 )
-if(WITH_APRILTAG)
-  rmvl_add_module(
-    tag_detector
-    DEPENDS detector planar_tracker tag 
-  )
-  rmvl_link_libraries(
-    tag_detector
-    PRIVATE apriltag
-  )
-endif()
+rmvl_add_module(
+  tag_detector
+  DEPENDS detector planar_tracker tag
+  EXTERNAL apriltag
+)
 
 rmvl_generate_module_para(detector)
 

--- a/modules/light/CMakeLists.txt
+++ b/modules/light/CMakeLists.txt
@@ -11,11 +11,7 @@ rmvl_update_build(opt_light_control OPTLightCtrl_FOUND)
 rmvl_add_module(
   opt_light_control
   DEPENDS core light
-)
-
-rmvl_link_libraries(
-  opt_light_control
-  PRIVATE optlc
+  EXTERNAL optlc
 )
 
 # hik_light_control


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [ ] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 增加 `BUILD_WORLD` 编译选项，在启用时，将所有源文件汇总成 `rmvl_world` 进行编译