### PR TITLE
OPC UA 对象（类型）节点增加对数据源变量节点的支持

### DIFF
--- a/doc/tools/pyrmvl_fns.cfg
+++ b/doc/tools/pyrmvl_fns.cfg
@@ -128,8 +128,7 @@ rm::Method             Method                       ""                          
 rm::Method             Method                       cb                               [[con]]
 rm::ObjectType         ObjectType                   ""                               [[con]]
 rm::ObjectType         add                          variable                         None
-rm::ObjectType         [[get]]                      browse_name                      variable
-rm::ObjectType         [[set]]                      browse_name,variable             None
+rm::ObjectType         add                          dsv                              None
 rm::ObjectType         add                          method                           None
 rm::ObjectType         empty                        ""                               [[Is_Empty_?]]
 rm::ObjectType         getVariables                 ""                               variables_map
@@ -138,9 +137,8 @@ rm::Object             Object                       ""                          
 rm::Object             makeFrom                     otype                            [[this]]
 rm::Object             type                         ""                               [[ObjectType]]
 rm::Object             add                          variable                         None
+rm::Object             add                          dsv                              None
 rm::Object             add                          method                           None
-rm::Object             [[get]]                      browse_name                      variable
-rm::Object             [[set]]                      browse_name,variable             None
 rm::Object             empty                        ""                               [[Is_Empty_?]]
 rm::Object             getVariables                 ""                               variables_map
 rm::Object             getMethods                   ""                               methods_map

--- a/modules/opcua/include/rmvl/opcua/object.hpp
+++ b/modules/opcua/include/rmvl/opcua/object.hpp
@@ -38,23 +38,21 @@ public:
      *
      * @param[in] variable 变量节点
      */
-    RMVL_W inline void add(const Variable &variable) { _variables[variable.browse_name] = variable; }
+    RMVL_W void add(const Variable &variable) { _variables[variable.browse_name] = variable; }
 
     /**
-     * @brief 访问指定的变量节点
+     * @brief 添加数据源变量节点至 `rm::Object` 对象中
      *
-     * @param[in] browse_name 变量节点的浏览名 BrowseName
-     * @return 用 `rm::Variable` 表示的变量的左值引用
+     * @param[in] dsv 数据源变量节点
      */
-    RMVL_W_SUBST("OT_Idx")
-    inline Variable &operator[](const std::string &browse_name) { return _variables[browse_name]; }
+    RMVL_W void add(const DataSourceVariable &dsv) { _ds_variables[dsv.browse_name] = dsv; }
 
     /**
      * @brief 添加方法节点至 `rm::ObjectType` 对象类型中
      *
      * @param[in] method 方法节点
      */
-    RMVL_W inline void add(const Method &method) { _methods[method.browse_name] = method; }
+    RMVL_W void add(const Method &method) { _methods[method.browse_name] = method; }
 
     /**
      * @brief 判断对象类型是否为空
@@ -77,14 +75,26 @@ public:
      */
     inline const ObjectType *base() const { return _base; }
 
-    RMVL_W inline const std::unordered_map<std::string, rm::Variable> &getVariables() const { return _variables; }
+    /**
+     * @brief 获取 `rm::Variable` 表示的变量节点的列表
+     * 
+     * @return 变量节点列表
+     */
+    RMVL_W const std::unordered_map<std::string, rm::Variable> &getVariables() const { return _variables; }
+
+    /**
+     * @brief 获取 `rm::DataSourceVariable` 表示的数据源变量节点的列表
+     * 
+     * @return 数据源变量节点列表
+     */
+    RMVL_W const std::unordered_map<std::string, rm::DataSourceVariable> &getDataSourceVariables() const { return _ds_variables; }
 
     /**
      * @brief 获取 `rm::Method` 表示的方法节点的列表
      *
      * @return 方法节点列表
      */
-    RMVL_W inline const std::unordered_map<std::string, rm::Method> &getMethods() const { return _methods; }
+    RMVL_W const std::unordered_map<std::string, rm::Method> &getMethods() const { return _methods; }
 
     //! 命名空间索引，默认为 `1`
     RMVL_W_RW uint16_t ns{1U};
@@ -125,6 +135,15 @@ private:
     std::unordered_map<std::string, Variable> _variables;
 
     /**
+     * @brief 数据源变量节点
+     * @brief
+     * - `Key`: 浏览名 BrowseName
+     * @brief
+     * - `Value`: 用 `rm::DataSourceVariable` 表示的数据源变量
+     */
+    std::unordered_map<std::string, DataSourceVariable> _ds_variables;
+
+    /**
      * @brief 方法节点
      * @brief
      * - `Key`: 浏览名 BrowseName
@@ -156,23 +175,21 @@ public:
      *
      * @param[in] variable 变量节点
      */
-    RMVL_W inline void add(const Variable &variable) { _variables[variable.browse_name] = variable; }
+    RMVL_W void add(const Variable &variable) { _variables[variable.browse_name] = variable; }
+
+    /**
+     * @brief 添加数据源变量节点至 `rm::Object` 对象中
+     *
+     * @param[in] dsv 数据源变量节点
+     */
+    RMVL_W void add(const DataSourceVariable &dsv) { _ds_variables[dsv.browse_name] = dsv; }
 
     /**
      * @brief 添加（额外的）方法节点至 `rm::Object` 对象中
      *
      * @param[in] method 方法节点
      */
-    RMVL_W inline void add(const Method &method) { _methods[method.browse_name] = method; }
-
-    /**
-     * @brief 访问指定的变量节点
-     *
-     * @param[in] browse_name 变量节点的浏览名 BrowseName
-     * @return 用 `rm::Variable` 表示的变量的左值引用
-     */
-    RMVL_W_SUBST("O_Idx")
-    inline Variable &operator[](const std::string &browse_name) { return _variables[browse_name]; }
+    RMVL_W void add(const Method &method) { _methods[method.browse_name] = method; }
 
     /**
      * @brief 判断对象是否为空
@@ -187,6 +204,13 @@ public:
      * @return 变量节点列表
      */
     RMVL_W inline const std::unordered_map<std::string, rm::Variable> &getVariables() const { return _variables; }
+
+    /**
+     * @brief 获取 `rm::DataSourceVariable` 表示的数据源变量节点的列表
+     *
+     * @return 数据源变量节点列表
+     */
+    RMVL_W inline const std::unordered_map<std::string, rm::DataSourceVariable> &getDataSourceVariables() const { return _ds_variables; }
 
     /**
      * @brief 获取 `rm::Method` 表示的方法节点的列表
@@ -232,6 +256,15 @@ private:
      * - `Value`: 用 `rm::Variable` 表示的变量
      */
     std::unordered_map<std::string, Variable> _variables;
+
+    /**
+     * @brief 数据源变量节点
+     * @brief
+     * - `Key`: 浏览名 BrowseName
+     * @brief
+     * - `Value`: 用 `rm::DataSourceVariable` 表示的数据源变量
+     */
+    std::unordered_map<std::string, DataSourceVariable> _ds_variables;
 
     /**
      * @brief 方法节点

--- a/modules/opcua/misc/python.json
+++ b/modules/opcua/misc/python.json
@@ -121,26 +121,6 @@
             "def __setitem__(self, browse_name: str, prop: int) -> None: ..."
         ]
     },
-    "OT_Idx": {
-        "bind": [
-            ".def(\"__getitem__\", [](ObjectType &ot, const std::string &name) -> Variable & { return ot[name]; })",
-            ".def(\"__setitem__\", [](ObjectType &ot, const std::string &name, const Variable &v) { ot[name] = v; })"
-        ],
-        "pyi": [
-            "def __getitem__(self, browse_name: str) -> int: ...",
-            "def __setitem__(self, browse_name: str, v: Variable) -> None: ..."
-        ]
-    },
-    "O_Idx": {
-        "bind": [
-            ".def(\"__getitem__\", [](Object &o, const std::string &name) -> Variable & { return o[name]; })",
-            ".def(\"__setitem__\", [](Object &o, const std::string &name, const Variable &v) { o[name] = v; })"
-        ],
-        "pyi": [
-            "def __getitem__(self, browse_name: str) -> int: ...",
-            "def __setitem__(self, browse_name: str, v: Variable) -> None: ..."
-        ]
-    },
     "View_Add": {
         "bind": [
             ".def(\"add\", [](View& self, py::args args) { for (const auto& arg : args) { self.add(arg.cast<NodeId>()); } })"

--- a/modules/opcua/test/test_opcua_server.cpp
+++ b/modules/opcua/test/test_opcua_server.cpp
@@ -117,6 +117,34 @@ TEST(OPC_UA_Server, add_object_node)
     auto id = srv.addObjectNode(object);
     EXPECT_FALSE(id.empty());
     srv.spinOnce();
+    // 路径搜索变量节点
+    auto val1_id = srv.find("test_object/test_val1");
+    EXPECT_FALSE(val1_id.empty());
+}
+
+// 服务器添加包含数据源变量节点的对象节点
+TEST(OPC_UA_Server, add_object_node_with_dsv)
+{
+    rm::Server srv(4837);
+    rm::Object object;
+    object.browse_name = "test_object";
+    object.description = "this is test object";
+    object.display_name = "测试对象";
+    rm::DataSourceVariable dsv1;
+    dsv1.browse_name = "test_dsv1";
+    dsv1.description = "this is test data source variable";
+    dsv1.display_name = "测试数据源变量 1";
+    dsv1.access_level = rm::VARIABLE_READ | rm::VARIABLE_WRITE;
+    int src_val{};
+    dsv1.on_read = [&](const rm::NodeId &) -> rm::Variable { return src_val; };
+    dsv1.on_write = [&](const rm::NodeId &, const rm::Variable &val) { src_val = val; };
+    object.add(dsv1);
+    auto id = srv.addObjectNode(object);
+    EXPECT_FALSE(id.empty());
+    srv.spinOnce();
+    // 路径搜索数据源变量节点
+    auto dsv_id = srv.find("test_object/test_dsv1");
+    EXPECT_FALSE(dsv_id.empty());
 }
 
 // 服务器添加包含方法节点的对象节点
@@ -141,6 +169,9 @@ TEST(OPC_UA_Server, add_object_node_with_method)
     auto id = srv.addObjectNode(object);
     EXPECT_FALSE(id.empty());
     srv.spinOnce();
+    // 路径搜索方法节点
+    auto method_id = srv.find("test_object/test_method");
+    EXPECT_FALSE(method_id.empty());
 }
 
 // 服务器添加对象类型节点


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [ ] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- `rm::Object` 和 `rm::ObjectType` 增加对数据源变量节点的支持，现可直接使用 `add` 方法完成对数据源变量节点的添加

### 本地单元测试结果

```
Running main() from /path/top/googletest/src/gtest_main.cc
[==========] Running 27 tests from 5 test suites.

...

[----------] 17 tests from OPC_UA_Server
...
[ RUN      ] OPC_UA_Server.add_object_node
[       OK ] OPC_UA_Server.add_object_node (100 ms)
[ RUN      ] OPC_UA_Server.add_object_node_with_dsv
[       OK ] OPC_UA_Server.add_object_node_with_dsv (100 ms)
[ RUN      ] OPC_UA_Server.add_object_node_with_method
[       OK ] OPC_UA_Server.add_object_node_with_method (100 ms)
[ RUN      ] OPC_UA_Server.add_object_type_node
[       OK ] OPC_UA_Server.add_object_type_node (100 ms)
...
[----------] 17 tests from OPC_UA_Server (1805 ms total)

...

[----------] Global test environment tear-down
[==========] 27 tests from 5 test suites ran. (4006 ms total)
[  PASSED  ] 27 tests.
````
