### PR TITLE
StateInfo 类型系统的 at 方法改为不存在则抛出 std::out_of_range 异常

### DIFF
--- a/extra/combo/include/rmvl/combo/armor.h
+++ b/extra/combo/include/rmvl/combo/armor.h
@@ -171,7 +171,7 @@ inline cv::Ptr<cv::ml::SVM> Armor::_svm = nullptr;
 /**
  * @brief 装甲板大小类型转为字符串
  *
- * @param[in] armor_size_type 装甲板大小类型
+ * @param[in] armor_size 装甲板大小类型
  */
 constexpr const char *to_string(ArmorSizeType armor_size)
 {

--- a/extra/feature/src/tag/tag.cpp
+++ b/extra/feature/src/tag/tag.cpp
@@ -24,7 +24,7 @@ Tag::Tag(const std::vector<cv::Point2f> &corners, char type)
     if (corners_size != 4)
         RMVL_Error_(RMVL_StsBadArg, "the size of the argument \"corners\" should be 4, but now it is %zu.", corners_size);
     _corners = std::vector<cv::Point2f>(corners.begin(), corners.end());
-    _state.at("tag: " + std::string(1, type));
+    _state["tag"] = type;
     cv::Point2f center;
     for (const auto &corner : corners)
         center += corner;

--- a/extra/group/src/gyro_group/init.cpp
+++ b/extra/group/src/gyro_group/init.cpp
@@ -9,8 +9,8 @@
  *
  */
 
-#include "rmvl/group/gyro_group.h"
 #include "rmvl/algorithm/transform.hpp"
+#include "rmvl/group/gyro_group.h"
 #include "rmvl/tracker/gyro_tracker.h"
 
 #include "rmvlpara/camera/camera.h"
@@ -33,7 +33,11 @@ GyroGroup::GyroGroup(const std::vector<combo::ptr> &first_combos, int armor_num)
     // 获取 RobotType
     std::vector<RobotType> robot_type_vec;
     for_each(first_combos.begin(), first_combos.end(), [&](combo::const_ptr val) {
-        robot_type_vec.push_back(to_robot_type(val->state().at("robot")));
+        const auto &state = val->state();
+        if (state.contains("robot"))
+            robot_type_vec.push_back(to_robot_type(state.at("robot")));
+        else
+            robot_type_vec.push_back(RobotType::UNKNOWN);
     });
     _state["robot"] = to_string(calculateModeNum(robot_type_vec.begin(), robot_type_vec.end()));
     // 获取序列组信息

--- a/extra/tracker/src/gyro_tracker/gyro_tracker.cpp
+++ b/extra/tracker/src/gyro_tracker/gyro_tracker.cpp
@@ -36,7 +36,7 @@ GyroTracker::GyroTracker(combo::ptr p_armor)
     _extrinsic = p_armor->extrinsic();
     _state = p_armor->state();
     _combo_deque.push_back(p_armor);
-    _type_deque.push_back(to_robot_type(_state.at("robot")));
+    _type_deque.push_back(to_robot_type(_state["robot"]));
     _duration = para::gyro_tracker_param.SAMPLE_INTERVAL / 1000.;
     initFilter();
 }
@@ -59,7 +59,10 @@ void GyroTracker::update(combo::ptr p_armor)
     _combo_deque.emplace_front(p_armor);
     // 更新装甲板类型
     const auto &armor_state = p_armor->state();
-    updateType(to_robot_type(armor_state.at("robot")));
+    if (armor_state.contains("robot"))
+        updateType(to_robot_type(armor_state.at("robot")));
+    else
+        updateType(RobotType::UNKNOWN);
     // 帧差时间计算
     if (_combo_deque.empty())
         RMVL_Error(RMVL_StsBadSize, "\"_combo_deque\" is empty");

--- a/extra/types/include/rmvl/types.hpp
+++ b/extra/types/include/rmvl/types.hpp
@@ -42,7 +42,6 @@ public:
      * @endcode
      *
      * @param[in] type 状态类型
-     * @return 是否添加成功
      */
     RMVL_W void add(std::string_view type);
 
@@ -60,13 +59,13 @@ public:
      * @param[in] key 状态类型
      * @return 是否包含
      */
-    RMVL_W bool contains(std::string_view key) const;
+    RMVL_W bool contains(std::string_view key) const noexcept;
 
     //! 清空状态类型
-    RMVL_W void clear();
+    RMVL_W void clear() noexcept;
 
     //! 状态类型是否为空
-    RMVL_W bool empty() const;
+    RMVL_W bool empty() const noexcept;
 
     /**
      * @brief 获取状态类型
@@ -74,7 +73,7 @@ public:
      * @param[in] key 状态类型
      * @return 状态
      */
-    std::string_view at(std::string_view key) const;
+    const std::string &at(std::string_view key) const;
 
     /**
      * @brief 设置状态类型
@@ -90,7 +89,7 @@ public:
      * @param[in] key 状态类型
      * @return 状态
      */
-    std::string &operator[](std::string_view key);
+    std::string &operator[](std::string_view key) noexcept;
 
     RMVL_W_SUBST("At")
 

--- a/extra/types/src/types.cpp
+++ b/extra/types/src/types.cpp
@@ -35,21 +35,16 @@ void StateInfo::add(std::string_view type)
 
 bool StateInfo::remove(std::string_view key) { return _states.erase(std::string(key)) > 0; }
 
-bool StateInfo::contains(std::string_view key) const { return _states.find(std::string(key)) != _states.end(); }
+bool StateInfo::contains(std::string_view key) const noexcept { return _states.find(std::string(key)) != _states.end(); }
 
-void StateInfo::clear() { _states.clear(); }
+void StateInfo::clear() noexcept { _states.clear(); }
 
-bool StateInfo::empty() const { return _states.empty(); }
+bool StateInfo::empty() const noexcept { return _states.empty(); }
 
-std::string_view StateInfo::at(std::string_view key) const
-{
-    if (!contains(key))
-        return "unknown";
-    return _states.at(std::string(key));
-}
+const std::string &StateInfo::at(std::string_view key) const { return _states.at(std::string(key)); }
 
-std::string &StateInfo::at(std::string_view key) { return _states[std::string(key)]; }
+std::string &StateInfo::at(std::string_view key) { return _states.at(std::string(key)); }
 
-std::string &StateInfo::operator[](std::string_view key) { return _states[std::string(key)]; }
+std::string &StateInfo::operator[](std::string_view key) noexcept { return _states[std::string(key)]; }
 
 } // namespace rm

--- a/modules/opcua/test/test_opcua_client.cpp
+++ b/modules/opcua/test/test_opcua_client.cpp
@@ -210,7 +210,7 @@ TEST(OPC_UA_Client, timer_test)
     std::this_thread::sleep_for(10ms);
     rm::Client cli("opc.tcp://127.0.0.1:5005");
     int times{};
-    auto timer = rm::ClientTimer(cli, 50., [&](rm::ClientView) { times++; });
+    auto timer = rm::ClientTimer(cli, 10, [&](rm::ClientView) { times++; });
     std::this_thread::sleep_for(60ms);
     cli.spinOnce();
     std::this_thread::sleep_for(60ms);

--- a/modules/opcua/test/test_opcua_server.cpp
+++ b/modules/opcua/test/test_opcua_server.cpp
@@ -313,7 +313,7 @@ TEST(OPC_UA_Server, timer_test)
 
     int times{};
 
-    auto timer = rm::ServerTimer(srv, 50, [&](rm::ServerView sv) {
+    auto timer = rm::ServerTimer(srv, 10, [&](rm::ServerView sv) {
         int num = sv.read(nd).cast<int>() + 10;
         sv.write(nd, num);
         times++;


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [ ] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 原先的 `at` 方法在访问不存在的类型时，会返回 `std::string` 类型的 `"unknown"`，现改变这一行为，改为由 STL 自行抛出 `std::out_of_range` 异常，同时返回类型更改为 `const std::string &`，与 `std::unordered_map` 的 `at` 方法行为一致