### PR TITLE
Variable 增加字符串字面量转换构造函数

### DIFF
--- a/modules/opcua/include/rmvl/opcua/variable.hpp
+++ b/modules/opcua/include/rmvl/opcua/variable.hpp
@@ -51,7 +51,16 @@ public:
      *
      * @param[in] str 字符串
      */
-    RMVL_W VariableType(std::string_view str) : _value(std::string(str)), _data_type(DataType(typeid(std::string))), _size(1) {}
+    RMVL_W VariableType(const std::string &str) : _value(str), _data_type(DataType(typeid(std::string))), _size(1) {}
+
+    /**
+     * @brief 字符串字面量构造
+     *
+     * @tparam N 字符串长度
+     * @param[in] str 字符串
+     */
+    template <std::size_t N>
+    VariableType(const char (&str)[N]) : VariableType(std::string(str, N)) {}
 
     /**
      * @brief 列表构造，设置默认值
@@ -148,7 +157,16 @@ public:
      *
      * @param[in] str 字符串
      */
-    RMVL_W Variable(std::string_view str) : access_level(3U), _value(std::string(str)), _data_type(DataType(typeid(std::string))), _size(1) {}
+    RMVL_W Variable(const std::string &str) : access_level(3U), _value(str), _data_type(DataType(typeid(std::string))), _size(1) {}
+
+    /**
+     * @brief 字符串字面量构造
+     *
+     * @tparam N 字符串长度
+     * @param[in] str 字符串
+     */
+    template <std::size_t N>
+    Variable(const char (&str)[N]) : Variable(std::string(str, N)) {}
 
     /**
      * @brief 列表构造
@@ -184,10 +202,10 @@ public:
      * @param[in] val 另一个变量
      * @return 是否不等
      */
-    RMVL_W inline bool operator!=(const Variable &val) const { return !(*this == val); }
+    RMVL_W bool operator!=(const Variable &val) const { return !(*this == val); }
 
     //! 判断变量节点是否为空
-    RMVL_W constexpr bool empty() const { return _size == 0; }
+    RMVL_W bool empty() const { return _size == 0; }
 
     /**
      * @brief 将变量节点转化为指定类型的数据

--- a/modules/opcua/src/client.cpp
+++ b/modules/opcua/src/client.cpp
@@ -50,7 +50,7 @@ Client::Client(std::string_view address, const UserConfig &usr)
         return;
     }
 
-    // 设置延迟时间
+    // 其余配置
     init_config.timeout = para::opcua_param.CONNECT_TIMEOUT;
 
     _client = UA_Client_newWithConfig(&init_config);

--- a/modules/opcua/src/helper.cpp
+++ b/modules/opcua/src/helper.cpp
@@ -303,7 +303,7 @@ Variable cvtVariable(const UA_Variant &p_val) noexcept
         case UA_TYPES_STRING: {
             UA_String *p_uastr = reinterpret_cast<UA_String *>(data);
             const char *str = reinterpret_cast<const char *>(p_uastr->data);
-            return std::string_view(str, p_uastr->length);
+            return std::string(str, p_uastr->length);
         }
         case UA_TYPES_BOOLEAN:
             return *reinterpret_cast<UA_Boolean *>(data);

--- a/modules/opcua/test/test_opcua_server.cpp
+++ b/modules/opcua/test/test_opcua_server.cpp
@@ -22,7 +22,7 @@ namespace rm_test
 TEST(OPC_UA_Server, variable_config)
 {
     // 变量类型节点、字符串
-    rm::VariableType variable_type{"string_test"};
+    rm::VariableType variable_type = "string_test";
     EXPECT_EQ(variable_type.size(), 1);
     EXPECT_EQ(variable_type.getDataType(), UA_TYPES_STRING);
     // 添加变量节点、双精度浮点数


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [ ] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- OPC UA 模块针对 `rm::Variable` 类增加字符串字面量的转换构造函数，以便于使用复制初始化
- 原先的 `std::string_view` 转换构造函数的参数改为 `const std::string &`