### PR TITLE
库文件版本号后缀只在 MSVC 下特化

### DIFF
--- a/cmake/RMVLCompilerOptions.cmake
+++ b/cmake/RMVLCompilerOptions.cmake
@@ -148,7 +148,7 @@ if(ENABLE_LTO)
   endif()
 endif()
 
-if(WIN32)
+if(RMVL_MSVC)
   # postfix of DLLs
   set(RMVL_LIBVERSION_SUFFIX "${RMVL_VERSION_MAJOR}${RMVL_VERSION_MINOR}${RMVL_VERSION_PATCH}" CACHE INTERNAL "RMVL library version suffix")
   set(RMVL_DEBUG_POSTFIX "d" CACHE INTERNAL "RMVL debug postfix")

--- a/cmake/RMVLModule.cmake
+++ b/cmake/RMVLModule.cmake
@@ -175,14 +175,12 @@ macro(rmvl_add_module _name)
           CACHE INTERNAL "Source files of RMVL modules"
         )
       else()
+        add_library(${the_module} ${target_src} ${para_src} ${extra_src})
         if(BUILD_SHARED_LIBS)
-          add_library(${the_module} SHARED ${target_src} ${para_src} ${extra_src})
           set_target_properties(
             ${the_module} PROPERTIES
             DEFINE_SYMBOL RMVLAPI_EXPORTS
           )
-        else()
-          add_library(${the_module} STATIC ${target_src} ${para_src} ${extra_src})
         endif()
       endif()
     endif(MD_INTERFACE)

--- a/doc/rmvl.bib
+++ b/doc/rmvl.bib
@@ -30,10 +30,12 @@
   year = {1960}
 }
 @software{microsoft23ort,
-  author = {microsoft},
-  title = {onnx runtime inference},
-  year = {2021},
-  url = {https://github.com/microsoft/onnxruntime}
+  author = {{ONNX Runtime developers}},
+  license = {MIT},
+  month = nov,
+  title = {{ONNX Runtime}},
+  url = {https://github.com/microsoft/onnxruntime},
+  year = {2018}
 }
 @software{AprilRobotics23,
   author = {AprilRobotics},

--- a/modules/algorithm/CMakeLists.txt
+++ b/modules/algorithm/CMakeLists.txt
@@ -3,11 +3,9 @@
 # ----------------------------------------------------------------------------
 rmvl_generate_para(algorithm)
 
+rmvl_add_module(algorithm DEPENDS core)
 if(WITH_OPENCV AND WITH_EIGEN3)
-  rmvl_add_module(algorithm DEPENDS core)
   rmvl_compile_definitions(algorithm PUBLIC HAVE_OPENCV)
-else()
-  rmvl_add_module(algorithm DEPENDS core)
 endif()
 
 # ----------------------------------------------------------------------------

--- a/modules/core/include/rmvl/core.hpp
+++ b/modules/core/include/rmvl/core.hpp
@@ -6,7 +6,7 @@
  * @date 2023-04-18
  *
  * @copyright Copyright 2023 (c), zhaoxi
- * 
+ *
  */
 
 #pragma once
@@ -42,6 +42,7 @@
 
 // 通用
 #include "core/io.hpp"
+#include "core/str.hpp"
 #include "core/timer.hpp"
 #include "core/util.hpp"
 #include "core/version.hpp"

--- a/modules/opcua/include/rmvl/opcua/client.hpp
+++ b/modules/opcua/include/rmvl/opcua/client.hpp
@@ -225,7 +225,7 @@ public:
      * 
      * @param[in] obj_nd 对象节点
      * @param[in] name 方法名
-     * @param[in] inputs 输入参数列表
+     * @param[in] args 方法的所有传入参数
      * @retval res, oargs
      * @return 是否成功完成当前操作，以及输出参数列表
      */
@@ -246,7 +246,7 @@ public:
      * @brief 直接以底层数据调用 ObjectsFolder 中的方法
      *
      * @param[in] name 方法名 `browse_name`
-     * @param[in] inputs 输入参数列表
+     * @param[in] args 方法的所有传入参数
      * @retval res, oargs
      * @return 是否成功完成当前操作，以及输出参数列表
      */

--- a/modules/opcua/include/rmvl/opcua/method.hpp
+++ b/modules/opcua/include/rmvl/opcua/method.hpp
@@ -41,7 +41,7 @@ struct RMVL_EXPORTS_W_AG Argument final
      * @param[in] desc 参数描述
      * @return 方法参数信息
      */
-    RMVL_W static Argument create(const std::string &name, DataType type, uint32_t dims = 1U, const std::string &desc = "") { return {name, type, dims, desc}; }
+    RMVL_W static Argument create(const std::string &name, DataType type, uint32_t dims = 1, const std::string &desc = "") { return {name, type, dims, desc}; }
 };
 
 /**

--- a/modules/opcua/include/rmvl/opcua/server.hpp
+++ b/modules/opcua/include/rmvl/opcua/server.hpp
@@ -12,7 +12,6 @@
 #pragma once
 
 #include <atomic>
-#include <unordered_set>
 
 #include "event.hpp"
 #include "object.hpp"


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [ ] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

原先 Windows 上使用 MinGW 编译工具链进行构建时，会出现形如 `librmvl211.a` 库文件，现只在 MSVC 编译器上生效
