### PR TITLE
解决 light 依赖第三方 SDK 时，构建提示动态库缺失的问题

### DIFF
--- a/modules/light/CMakeLists.txt
+++ b/modules/light/CMakeLists.txt
@@ -30,6 +30,36 @@ rmvl_add_module(
 # ----------------------------------------------------------------------------
 rmvl_generate_module_para(light)
 
+# --------------------------------------------------------------------------
+#   Install the necessary library for OS
+# --------------------------------------------------------------------------
+foreach(SDK OPTLightCtrl)
+  if(${SDK}_FOUND AND DEFINED ${SDK}_LIB)
+    if(IS_SYMLINK "${${SDK}_LIB}")
+      get_filename_component(lib_realname ${${SDK}_LIB} REALPATH)
+      set(lib_install ${lib_realname} ${${SDK}_LIB})
+    else()
+      set(lib_install ${${SDK}_LIB})
+    endif()
+    install(
+      FILES ${lib_install}
+      DESTINATION ${RMVL_3P_LIB_INSTALL_PATH}
+    )
+    if(DEFINED ${SDK}_DLL)
+      if(IS_SYMLINK "${${SDK}_DLL}")
+        get_filename_component(dll_realname ${${SDK}_DLL} REALPATH)
+        set(dll_install ${dll_realname} ${${SDK}_DLL})
+      else()
+        set(dll_install ${${SDK}_DLL})
+      endif()
+      install(
+        FILES ${dll_install}
+        DESTINATION ${RMVL_BIN_INSTALL_PATH}
+      )
+    endif()
+  endif()
+endforeach()
+
 # ----------------------------------------------------------------------------
 #  Build Python bindings
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [ ] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 类比 `camera` 模块，为 `light` 模块的 `opt_light_control` 增加第三方动态库的自动安装，以避免用户在构建时提示类似
  ```
  ninja: error: '/usr/local/lib/RMVL/3rdparty/libOPTController.so', needed by 'server', missing and no known rule to make it
  ```
  的动态库缺失信息
