### PR TITLE
移除数据组件冗余的构造函数，将大部分构造操作移动至对应的工厂函数

### DIFF
--- a/extra/combo/include/rmvl/combo/armor.h
+++ b/extra/combo/include/rmvl/combo/armor.h
@@ -61,7 +61,7 @@ public:
 
     //! @cond
     Armor() = default;
-    Armor(LightBlob::ptr, LightBlob::ptr, const ImuData &, double, float, float, float, float, float, float, float, ArmorSizeType);
+    Armor(float, float, float, float);
     //! @endcond
 
     /**
@@ -152,9 +152,6 @@ public:
     RMVL_W const cv::Vec2f &getPose() const { return _pose; }
 
 private:
-    //! 用来确定装甲板的种类 (大装甲或者小装甲)
-    ArmorSizeType matchArmorType();
-
     float _combo_ratio{};  //!< 组合特征宽高比
     float _width_ratio{};  //!< 左右灯条宽度比
     float _length_ratio{}; //!< 左右灯条长度比

--- a/extra/combo/src/armor/armor_cal.cpp
+++ b/extra/combo/src/armor/armor_cal.cpp
@@ -19,33 +19,6 @@
 namespace rm
 {
 
-ArmorSizeType Armor::matchArmorType()
-{
-    if (_svm != nullptr)
-    {
-        cv::Matx15f test_sample = {_combo_ratio,   // 装甲板长宽比
-                                   _width_ratio,   // 灯条宽度比
-                                   _length_ratio}; // 灯条长度比
-        auto res = _svm->predict(test_sample);
-        return res == 1 ? ArmorSizeType::SMALL : ArmorSizeType::BIG;
-    }
-    // 装甲板长宽比例符合
-    if (_combo_ratio < para::armor_param.MAX_SMALL_COMBO_RATIO)
-        return ArmorSizeType::SMALL;
-    else if (_combo_ratio > para::armor_param.MIN_BIG_COMBO_RATIO)
-        return ArmorSizeType::BIG;
-    // 错位角判断
-    if (abs(_corner_angle) < para::armor_param.MAX_SMALL_CORNER_ANGLE)
-        return ArmorSizeType::SMALL;
-    else if (abs(_corner_angle) > para::armor_param.MIN_BIG_CORNER_ANGLE)
-        return ArmorSizeType::BIG;
-    // 宽度比例判断
-    if (_width_ratio < para::armor_param.BIG_SMALL_WIDTH_RATIO)
-        return ArmorSizeType::SMALL; // 装甲板长宽比例较小
-    else
-        return ArmorSizeType::BIG;
-}
-
 void Armor::imuConvertToCamera(const cv::Matx33f &gyro_rmat, const cv::Vec3f &gyro_tvec,
                                const ImuData &imu_data, cv::Matx33f &cam_rmat, cv::Vec3f &cam_tvec)
 {

--- a/extra/feature/include/rmvl/feature/light_blob.h
+++ b/extra/feature/include/rmvl/feature/light_blob.h
@@ -25,19 +25,9 @@ namespace rm
  */
 class RMVL_EXPORTS_W_DES LightBlob : public feature
 {
-    cv::RotatedRect _rotated_rect; //!< 旋转矩形
-    cv::Point2f _top;              //!< 上顶点
-    cv::Point2f _bottom;           //!< 下顶点
-
 public:
     using ptr = std::shared_ptr<LightBlob>;
     using const_ptr = std::shared_ptr<const LightBlob>;
-
-    //! @cond
-    LightBlob() = default;
-    LightBlob(const cv::Point2f &, const cv::Point2f &, float);
-    LightBlob(const std::vector<cv::Point> &, cv::RotatedRect &, float, float);
-    //! @endcond
 
     //! 获取灯条顶端点
     RMVL_W inline const cv::Point2f &getTopPoint() const { return _top; }
@@ -60,7 +50,7 @@ public:
      * @param[in] width 灯条宽度
      * @return 若构造成功则返回 LightBlob 的共享指针，否则返回 nullptr
      */
-    RMVL_W static inline ptr make_feature(const cv::Point2f &top, const cv::Point2f &bottom, float width) { return std::make_shared<LightBlob>(top, bottom, width); }
+    RMVL_W static ptr make_feature(const cv::Point2f &top, const cv::Point2f &bottom, float width);
 
     /**
      * @brief 从另一个特征进行构造
@@ -72,13 +62,8 @@ public:
     RMVL_FEATURE_CAST(LightBlob)
 
 private:
-    /**
-     * @brief 计算准确的特征信息
-     *
-     * @param[in] lw_ratio 长宽比
-     * @param[in] contour 轮廓点
-     */
-    void calcAccurateInfo(float lw_ratio, const std::vector<cv::Point> &contour);
+    cv::Point2f _top;    //!< 上顶点
+    cv::Point2f _bottom; //!< 下顶点
 };
 
 //! @} light_blob

--- a/extra/feature/include/rmvl/feature/pilot.h
+++ b/extra/feature/include/rmvl/feature/pilot.h
@@ -25,19 +25,9 @@ namespace rm
  */
 class RMVL_EXPORTS_W_DES Pilot : public feature
 {
-private:
-    cv::RotatedRect _rotated_rect; //!< 旋转矩形
-    cv::Point2f _left;             //!< 左顶点
-    cv::Point2f _right;            //!< 右顶点
-
 public:
     using ptr = std::shared_ptr<Pilot>;
     using const_ptr = std::shared_ptr<const Pilot>;
-
-    //! @cond
-    Pilot(const std::vector<cv::Point> &, cv::RotatedRect &, float, float);
-    Pilot(const float &, const float &, const cv::Point2f &, const float &, const std::vector<cv::Point2f> &);
-    //! @endcond
 
     /**
      * @brief 构造接口
@@ -51,17 +41,14 @@ public:
     /**
      * @brief 构造 Pilot
      *
-     * @param[in] ref_width 参考宽度
-     * @param[in] ref_height 参考高度
-     * @param[in] ref_center 参考中心点
-     * @param[in] ref_angle 参考角度
-     * @param[in] ref_corners 参考角点
-     * @return 返回 Pilot 的共享指针
+     * @param[in] w 参考宽度
+     * @param[in] h 参考高度
+     * @param[in] center 参考中心点
+     * @param[in] angle 参考角度
+     * @param[in] corners 参考角点
+     * @return Pilot 的共享指针
      */
-    RMVL_W static inline ptr make_feature(float ref_width, float ref_height, const cv::Point2f &ref_center, float ref_angle, const std::vector<cv::Point2f> &ref_corners)
-    {
-        return std::make_shared<Pilot>(ref_width, ref_height, ref_center, ref_angle, ref_corners);
-    }
+    RMVL_W static ptr make_feature(float w, float h, const cv::Point2f &center, float angle, const std::vector<cv::Point2f> &corners);
 
     /**
      * @brief 从另一个特征进行构造

--- a/extra/feature/include/rmvl/feature/rune_center.h
+++ b/extra/feature/include/rmvl/feature/rune_center.h
@@ -22,19 +22,9 @@ namespace rm
 //! 神符中心特征
 class RMVL_EXPORTS_W_DES RuneCenter : public feature
 {
-private:
-    std::vector<cv::Point> _contour; //!< 轮廓点集
-    cv::RotatedRect _rotated_rect;   //!< 旋转矩形
-    float _ratio{};                  //!< 长宽比
-
 public:
     using ptr = std::shared_ptr<RuneCenter>;
     using const_ptr = std::shared_ptr<const RuneCenter>;
-
-    //! @cond
-    RuneCenter(const std::vector<cv::Point> &, cv::RotatedRect &);
-    RuneCenter(const cv::Point2f &);
-    //! @endcond
 
     /**
      * @brief 使用特征中心点构造 RuneCenter 的构造接口
@@ -42,7 +32,7 @@ public:
      * @param[in] center 特征中心点
      * @return 如果成功，返回 RuneCenter 的共享指针，否则返回 nullptr
      */
-    RMVL_W static inline ptr make_feature(const cv::Point2f &center) { return std::make_shared<RuneCenter>(center); }
+    RMVL_W static ptr make_feature(const cv::Point2f &center);
 
     /**
      * @brief 使用轮廓和层次结构构造 RuneCenter 的构造接口

--- a/extra/feature/include/rmvl/feature/rune_target.h
+++ b/extra/feature/include/rmvl/feature/rune_target.h
@@ -28,7 +28,6 @@ public:
 
     //! @cond
     RuneTarget() = default;
-    RuneTarget(const std::vector<cv::Point> &, const cv::RotatedRect &, bool is_active);
     RuneTarget(const cv::Point &center, bool is_active);
     //! @endcond
 
@@ -48,7 +47,7 @@ public:
      * @param[in] is_active 是否激活？
      * @return 如果成功，返回 RuneTarget 的共享指针，否则返回 nullptr
      */
-    RMVL_W static ptr make_feature(const cv::Point &center, bool is_active);
+    RMVL_W static ptr make_feature(const cv::Point &center, bool is_active) { return std::make_shared<RuneTarget>(center, is_active); }
 
     /**
      * @brief 从另一个特征进行构造
@@ -65,11 +64,8 @@ public:
     RMVL_W inline float getRadius() const { return _radius; }
 
 private:
-    std::vector<cv::Point> _contour; //!< 轮廓点集
-    cv::RotatedRect _rotated_rect;   //!< 旋转矩形
-    float _ratio{};                  //!< 长宽比
-    bool _is_active{};               //!< 是否处于激活状态
-    float _radius{};                 //!< 半径
+    bool _is_active{}; //!< 是否处于激活状态
+    float _radius{};   //!< 半径
 };
 
 //! @} rune_target

--- a/extra/feature/include/rmvl/feature/tag.h
+++ b/extra/feature/include/rmvl/feature/tag.h
@@ -26,10 +26,6 @@ public:
     using ptr = std::shared_ptr<Tag>;
     using const_ptr = std::shared_ptr<const Tag>;
 
-    //! @cond
-    Tag(const std::vector<cv::Point2f> &corners, char type);
-    //! @endcond
-
     /**
      * @brief 构造 Tag 对象
      *
@@ -37,13 +33,7 @@ public:
      * @param[in] type AprilTag 视觉标签类型，包含 `A` 到 `Z` 和 `0` 到 `9`
      * @return 构造成功返回 Tag 共享指针，否则返回 `nullptr`
      */
-    RMVL_W static inline ptr make_feature(const std::vector<cv::Point2f> &corners, char type)
-    {
-        if ((type >= 'A' && type <= 'Z') || (type >= '0' && type <= '9'))
-            return std::make_shared<Tag>(corners, type);
-        else
-            return nullptr;
-    }
+    RMVL_W static ptr make_feature(const std::vector<cv::Point2f> &corners, char type);
 
     /**
      * @brief 从另一个特征进行构造

--- a/extra/feature/src/light_blob/light_blob.cpp
+++ b/extra/feature/src/light_blob/light_blob.cpp
@@ -19,61 +19,63 @@
 namespace rm
 {
 
-void LightBlob::calcAccurateInfo(float lw_ratio, const std::vector<cv::Point> &contour)
+static void calcAccurateInfo(float lw_ratio, const std::vector<cv::Point> &contour, float angle,
+                             cv::Point2f &top, cv::Point2f &bottom, cv::Point2f &center,
+                             float &width, float &height, std::vector<cv::Point2f> &corners)
 {
     // angle 向量
-    const float rad_angle = deg2rad(_angle);
-    const float cos_angle = cos(rad_angle);
-    const float sin_angle = sin(rad_angle);
+    const float rad_angle = deg2rad(angle);
+    const float cos_angle = std::cos(rad_angle);
+    const float sin_angle = std::sin(rad_angle);
     // 轮廓分割
     std::vector<cv::Point> up_contour, down_contour;
     up_contour.reserve(contour.size() >> 1);
     down_contour.reserve(contour.size() >> 1);
-    float height_bias = 0.25f * _height * cos_angle;
+    float height_bias = 0.25f * height * cos_angle;
     for (auto &point : contour)
     {
-        if (point.y < _center.y - height_bias)
+        if (point.y < center.y - height_bias)
             up_contour.emplace_back(point);
-        else if (point.y > _center.y + height_bias)
+        else if (point.y > center.y + height_bias)
             down_contour.emplace_back(point);
     }
     if (lw_ratio < para::light_blob_param.RATIO_THRESHOLD)
     {
-        cv::Vec4f line_vec = {sin_angle, -cos_angle, _center.x, _center.y};
-        _top = *min_element(up_contour.begin(), up_contour.end(), [&](const cv::Point &lhs, const cv::Point &rhs) {
+        cv::Vec4f line_vec = {sin_angle, -cos_angle, center.x, center.y};
+        top = *min_element(up_contour.begin(), up_contour.end(), [&](const cv::Point &lhs, const cv::Point &rhs) {
             return getDistance(line_vec, lhs, false) < getDistance(line_vec, rhs, false);
         });
-        _bottom = *min_element(down_contour.begin(), down_contour.end(), [&](const cv::Point &lhs, const cv::Point &rhs) {
+        bottom = *min_element(down_contour.begin(), down_contour.end(), [&](const cv::Point &lhs, const cv::Point &rhs) {
             return getDistance(line_vec, lhs, false) < getDistance(line_vec, rhs, false);
         });
     }
     else
     {
         // 寻找上下顶点
-        cv::Vec4f line_vec = {cos_angle, sin_angle, _center.x, _center.y}; // 方向为角度向量的法向量
-        _top = *max_element(up_contour.begin(), up_contour.end(), [&](const cv::Point &lhs, const cv::Point &rhs) {
+        cv::Vec4f line_vec = {cos_angle, sin_angle, center.x, center.y}; // 方向为角度向量的法向量
+        top = *max_element(up_contour.begin(), up_contour.end(), [&](const cv::Point &lhs, const cv::Point &rhs) {
             return getDistance(line_vec, lhs, false) < getDistance(line_vec, rhs, false);
         });
-        _bottom = *max_element(down_contour.begin(), down_contour.end(), [&](const cv::Point &lhs, const cv::Point &rhs) {
+        bottom = *max_element(down_contour.begin(), down_contour.end(), [&](const cv::Point &lhs, const cv::Point &rhs) {
             return getDistance(line_vec, lhs, false) < getDistance(line_vec, rhs, false);
         });
     }
     // 更新灯条中点
-    _center = (_top + _bottom) / 2.f;
+    center = (top + bottom) / 2.f;
     // 长度更新，宽度同比缩放
-    float temp_height = getDistance(_top, _bottom);
-    float temp_width = temp_height / _height * _width;
-    _rotated_rect.size.height = _height = temp_height;
-    _rotated_rect.size.width = _width = temp_width;
+    float temp_height = getDistance(top, bottom);
+    float temp_width = temp_height / height * width;
+    height = temp_height;
+    width = temp_width;
     // 角点更新
     float half_w = temp_width / 2;
-    _corners = {_bottom + cv::Point2f(-half_w * cos_angle, -half_w * sin_angle),
-                _top + cv::Point2f(-half_w * cos_angle, -half_w * sin_angle),
-                _top + cv::Point2f(half_w * cos_angle, half_w * sin_angle),
-                _bottom + cv::Point2f(half_w * cos_angle, half_w * sin_angle)};
+    corners = {bottom + cv::Point2f(-half_w * cos_angle, -half_w * sin_angle),
+               top + cv::Point2f(-half_w * cos_angle, -half_w * sin_angle),
+               top + cv::Point2f(half_w * cos_angle, half_w * sin_angle),
+               bottom + cv::Point2f(half_w * cos_angle, half_w * sin_angle)};
 }
 
-std::shared_ptr<LightBlob> LightBlob::make_feature(const std::vector<cv::Point> &contour)
+LightBlob::ptr LightBlob::make_feature(const std::vector<cv::Point> &contour)
 {
     // init
     if (contour.size() < 6)
@@ -108,49 +110,50 @@ std::shared_ptr<LightBlob> LightBlob::make_feature(const std::vector<cv::Point> 
             return nullptr;
     }
     // 构造返回
-    return std::make_shared<LightBlob>(contour, rotated_rect, lw_ratio, angle);
-}
+    auto retval = std::make_shared<LightBlob>();
 
-LightBlob::LightBlob(const std::vector<cv::Point> &contour, cv::RotatedRect &rotated_rect, float lw_ratio, float angle)
-    : _rotated_rect(rotated_rect)
-{
-    _angle = angle;
+    retval->_angle = angle;
     // 记录包围矩形角点
-    _corners.resize(4);
-    _rotated_rect.points(_corners.data());
+    auto &corners = retval->_corners;
+    corners.resize(4);
+    rotated_rect.points(corners.data());
     // 点从上到下排序
-    sort(_corners.begin(), _corners.end(), [](const cv::Point2f &lhs, const cv::Point2f &rhs) {
+    sort(corners.begin(), corners.end(), [](const cv::Point2f &lhs, const cv::Point2f &rhs) {
         return lhs.y < rhs.y;
     });
 
     // 获得粗略的上下顶点和长宽
-    _top = (_corners[0] + _corners[1]) / 2;
-    _bottom = (_corners[2] + _corners[3]) / 2;
-    _height = _rotated_rect.size.height;
-    _width = _rotated_rect.size.width;
-    _center = _rotated_rect.center;
+    retval->_top = (corners[0] + corners[1]) / 2;
+    retval->_bottom = (corners[2] + corners[3]) / 2;
+    retval->_height = rotated_rect.size.height;
+    retval->_width = rotated_rect.size.width;
+    retval->_center = rotated_rect.center;
     // 修正灯条匹配误差，获得精准的上下顶点和长宽度
-    calcAccurateInfo(lw_ratio, contour);
+    calcAccurateInfo(lw_ratio, contour, angle, retval->_top, retval->_bottom, retval->_center, retval->_width, retval->_height, corners);
+
+    return retval;
 }
 
-LightBlob::LightBlob(const cv::Point2f &top, const cv::Point2f &bottom, float width)
+LightBlob::ptr LightBlob::make_feature(const cv::Point2f &top, const cv::Point2f &bottom, float width)
 {
-    // 顶点构建不设置筛选，仅设置异常
+    // 顶点筛选
     if (std::isnan(top.x) || std::isnan(top.y) || top.x < -10000.f || top.x > 10000.f || top.y < -10000.f || top.y > 10000.f)
-        RMVL_Error_(RMVL_StsBadArg, "Argument \"top\" is invalid, x = %.5f, y = %.5f", top.x, top.y);
+        return nullptr;
     if (std::isnan(bottom.x) || std::isnan(bottom.y) || bottom.x < -10000.f || bottom.x > 10000.f || bottom.y < -10000.f || bottom.y > 10000.f)
-        RMVL_Error_(RMVL_StsBadArg, "Argument \"bottom\" is invalid, x = %.5f, y = %.5f", bottom.x, bottom.y);
+        return nullptr;
     if (std::isnan(width) || width < 0 || width > 10000.f)
-        RMVL_Error_(RMVL_StsBadArg, "Argument \"width\" is invalid, value is: %.5f", width);
+        return nullptr;
+
+    auto retval = std::make_shared<LightBlob>();
 
     // 设置灯条参数
-    _top = top;
-    _bottom = bottom;
-    _center = (top + bottom) / 2.f;
-    _angle = getVAngle(_bottom, _top, DEG);
-    _height = getDistance(_top, _bottom);
-    _width = width;
-    _corners.reserve(4);
+    retval->_top = top;
+    retval->_bottom = bottom;
+    retval->_center = (top + bottom) / 2.f;
+    retval->_angle = getVAngle(bottom, top, DEG);
+    retval->_height = getDistance(top, bottom);
+    retval->_width = width;
+    retval->_corners.reserve(4);
     // 设置灯条角点
     cv::Vec2f vertical_vec = {top.x - bottom.x,
                               top.y - bottom.y};
@@ -158,10 +161,11 @@ LightBlob::LightBlob(const cv::Point2f &top, const cv::Point2f &bottom, float wi
                          vertical_vec(1) * vertical_vec(1));
     cv::Point2f vertical_point(-vertical_vec(1) * width / 2.f,
                                vertical_vec(0) * width / 2.f);
-    _corners = {_top + vertical_point,
-                _top - vertical_point,
-                _bottom + vertical_point,
-                _bottom - vertical_point};
+    retval->_corners = {top + vertical_point,
+                        top - vertical_point,
+                        bottom + vertical_point,
+                        bottom - vertical_point};
+    return retval;
 }
 
 } // namespace rm

--- a/extra/feature/src/rune_center/rune_center.cpp
+++ b/extra/feature/src/rune_center/rune_center.cpp
@@ -19,31 +19,20 @@
 namespace rm
 {
 
-RuneCenter::RuneCenter(const cv::Point2f &center)
+RuneCenter::ptr RuneCenter::make_feature(const cv::Point2f &center)
 {
+    auto retval = std::make_shared<RuneCenter>();
     // 初始化构造形状信息
-    _center = center;
-    _width = 20;
-    _height = 20;
-    _ratio = 1;
+    retval->_center = center;
+    retval->_width = 20;
+    retval->_height = 20;
     // 更新角点信息
-    _corners = {center + cv::Point2f(-10, 10), center + cv::Point2f(-10, -10),
-                 center + cv::Point2f(10, -10), center + cv::Point2f(10, 10)};
+    retval->_corners = {center + cv::Point2f(-10, 10), center + cv::Point2f(-10, -10),
+                        center + cv::Point2f(10, -10), center + cv::Point2f(10, 10)};
+    return retval;
 }
 
-RuneCenter::RuneCenter(const std::vector<cv::Point> &contour, cv::RotatedRect &rotated_rect) : _rotated_rect(rotated_rect)
-{
-    _contour = contour;
-    _center = _rotated_rect.center;
-    _width = std::max(_rotated_rect.size.width, _rotated_rect.size.height);
-    _height = std::min(_rotated_rect.size.width, _rotated_rect.size.height);
-    _ratio = _width / _height;
-    // 更新角点信息
-    _corners.resize(4);
-    _rotated_rect.points(_corners.data());
-}
-
-std::shared_ptr<RuneCenter> RuneCenter::make_feature(const std::vector<cv::Point> &contour)
+RuneCenter::ptr RuneCenter::make_feature(const std::vector<cv::Point> &contour)
 {
     if (contour.size() < 6)
         return nullptr;
@@ -71,7 +60,15 @@ std::shared_ptr<RuneCenter> RuneCenter::make_feature(const std::vector<cv::Point
     }
     DEBUG_PASS_("center 2.center_ratio : pass");
 
-    return std::make_shared<RuneCenter>(contour, rotated_rect);
+    auto retval = std::make_shared<RuneCenter>();
+
+    retval->_center = rotated_rect.center;
+    retval->_width = std::max(rotated_rect.size.width, rotated_rect.size.height);
+    retval->_height = std::min(rotated_rect.size.width, rotated_rect.size.height);
+    // 更新角点信息
+    retval->_corners.resize(4);
+    rotated_rect.points(retval->_corners.data());
+    return retval;
 }
 
 } // namespace rm

--- a/extra/feature/src/rune_target/rune_target.cpp
+++ b/extra/feature/src/rune_target/rune_target.cpp
@@ -70,12 +70,24 @@ std::shared_ptr<RuneTarget> RuneTarget::make_feature(const std::vector<cv::Point
     }
     DEBUG_PASS_("target 4.contour_area : pass");
 
-    return std::make_shared<RuneTarget>(contour, rotated_rect, is_active);
-}
+    auto retval = std::make_shared<RuneTarget>();
+    retval->_angle = 0.f;
+    retval->_center = rotated_rect.center;
+    retval->_width = std::max(rotated_rect.size.width, rotated_rect.size.height);
+    retval->_height = std::min(rotated_rect.size.width, rotated_rect.size.height);
 
-std::shared_ptr<RuneTarget> RuneTarget::make_feature(const cv::Point &center, bool is_active)
-{
-    return std::make_shared<RuneTarget>(center, is_active);
+    std::vector<cv::Point2f> corners;
+    corners.reserve(4);
+    float radius = (retval->_height + retval->_width) / 4;
+    retval->_radius = radius;
+    corners.emplace_back(rotated_rect.center + cv::Point2f(-radius, radius));
+    corners.emplace_back(rotated_rect.center + cv::Point2f(-radius, -radius));
+    corners.emplace_back(rotated_rect.center + cv::Point2f(radius, -radius));
+    corners.emplace_back(rotated_rect.center + cv::Point2f(radius, radius));
+    retval->_corners = corners;
+    retval->_is_active = is_active;
+
+    return retval;
 }
 
 RuneTarget::RuneTarget(const cv::Point &center, bool is_active) : _is_active(is_active)
@@ -84,28 +96,6 @@ RuneTarget::RuneTarget(const cv::Point &center, bool is_active) : _is_active(is_
     _angle = 0.f;
     _width = 16.f;
     _height = 16.f;
-    _ratio = 1;
-}
-
-RuneTarget::RuneTarget(const std::vector<cv::Point> &contour, const cv::RotatedRect &rotated_rect, bool is_active) : _rotated_rect(rotated_rect)
-{
-    _contour = contour;
-    _angle = 0.f;
-    _center = _rotated_rect.center;
-    _width = std::max(_rotated_rect.size.width, _rotated_rect.size.height);
-    _height = std::min(_rotated_rect.size.width, _rotated_rect.size.height);
-    _ratio = _width / _height;
-
-    std::vector<cv::Point2f> corners;
-    corners.reserve(4);
-    float radius = (_height + _width) / 4;
-    _radius = radius;
-    corners.emplace_back(_center.x - radius, _center.y + radius);
-    corners.emplace_back(_center.x - radius, _center.y - radius);
-    corners.emplace_back(_center.x + radius, _center.y - radius);
-    corners.emplace_back(_center.x + radius, _center.y + radius);
-    _corners = corners;
-    _is_active = is_active;
 }
 
 } // namespace rm

--- a/extra/feature/src/tag/tag.cpp
+++ b/extra/feature/src/tag/tag.cpp
@@ -17,24 +17,25 @@
 namespace rm
 {
 
-Tag::Tag(const std::vector<cv::Point2f> &corners, char type)
+Tag::ptr Tag::make_feature(const std::vector<cv::Point2f> &corners, char type)
 {
-    RMVL_DbgAssert((type >= 'A' && type <= 'Z') || (type >= '0' && type <= '9'));
-    size_t corners_size = corners.size();
-    if (corners_size != 4)
-        RMVL_Error_(RMVL_StsBadArg, "the size of the argument \"corners\" should be 4, but now it is %zu.", corners_size);
-    _corners = std::vector<cv::Point2f>(corners.begin(), corners.end());
-    _state["tag"] = std::string(type, 1);
+    if (type <= '0' || (type >= '9' && type <= 'A') || (type >= 'Z' && type <= 'a') || type >= 'z')
+        return nullptr;
+    if (corners.size() != 4)
+        return nullptr;
+    auto retval = std::make_shared<Tag>();
+
+    retval->_corners = std::vector<cv::Point2f>(corners.begin(), corners.end());
+    retval->_state["tag"] = std::string(1, type);
     cv::Point2f center;
-    for (const auto &corner : corners)
-        center += corner;
-    center /= static_cast<float>(corners_size);
-    _center = center;
+    retval->_center = std::accumulate(corners.begin(), corners.end(), cv::Point2f(0, 0)) / 4.f;
 
     double length1 = getDistance(corners[0], corners[1]);
     double length2 = getDistance(corners[1], corners[2]);
-    _width = length1 > length2 ? length1 : length2;
-    _height = _width == length1 ? length2 : length1;
+    retval->_width = std::max(length1, length2);
+    retval->_height = std::min(length1, length2);
+
+    return retval;
 }
 
 } // namespace rm

--- a/modules/ml/include/rmvl/ml/ort.h
+++ b/modules/ml/include/rmvl/ml/ort.h
@@ -50,19 +50,6 @@ struct RMVL_EXPORTS_W_AG PostprocessOptions
 //! ONNX-Runtime (Ort) 部署库基类 \cite microsoft23ort
 class RMVL_EXPORTS_W OnnxNet
 {
-protected:
-    Ort::MemoryInfo _memory_info;           //!< 内存分配信息
-    Ort::Env _env;                          //!< 环境配置
-    Ort::SessionOptions _session_options;   //!< 会话选项
-    std::unique_ptr<Ort::Session> _session; //!< 会话
-#if ORT_API_VERSION < 12
-    std::vector<const char *> _inames; //!< 输入名称
-    std::vector<const char *> _onames; //!< 输出名称
-#else
-    std::vector<Ort::AllocatedStringPtr> _inames; //!< 输入名称
-    std::vector<Ort::AllocatedStringPtr> _onames; //!< 输出名称
-#endif
-
 public:
     /**
      * @brief 创建 OnnxNet 对象
@@ -108,6 +95,19 @@ private:
      * @return 使用 `std::any` 表示的所有推理结果，需要根据具体的网络进行解析
      */
     virtual std::any postProcess(const std::vector<Ort::Value> &output_tensors, const PostprocessOptions &postop);
+
+protected:
+    Ort::MemoryInfo _memory_info;           //!< 内存分配信息
+    Ort::Env _env;                          //!< 环境配置
+    Ort::SessionOptions _session_options;   //!< 会话选项
+    std::unique_ptr<Ort::Session> _session; //!< 会话
+#if ORT_API_VERSION < 12
+    std::vector<const char *> _inames; //!< 输入名称
+    std::vector<const char *> _onames; //!< 输出名称
+#else
+    std::vector<Ort::AllocatedStringPtr> _inames; //!< 输入名称
+    std::vector<Ort::AllocatedStringPtr> _onames; //!< 输出名称
+#endif
 };
 
 /**
@@ -120,8 +120,6 @@ private:
  */
 class RMVL_EXPORTS_W ClassificationNet : public OnnxNet
 {
-    std::vector<std::vector<float>> _iarrays; //!< 输入数组
-
 public:
     /**
      * @brief 推理结果转换
@@ -157,6 +155,8 @@ private:
      * @return 用 `std::any` 表示的分类结果及其置信度，可使用 `rm::ClassificationNet::cast` 函数对返回类型进行转换
      */
     std::any postProcess(const std::vector<Ort::Value> &output_tensors, const PostprocessOptions &postop) override;
+
+    std::vector<std::vector<float>> _iarrays; //!< 输入数组
 };
 
 //! @} ml_ort


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [ ] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 移除所有 `feature` 组件以及 `rm::Armor` 冗余的构造函数，将大部分构造操作移动至对应的工厂函数 `make_feature` 以及 `make_combo` 当中