### PR TITLE
OPC UA 客户端定时器 Callback 移除客户端视图的传入参数

### DIFF
--- a/modules/opcua/include/rmvl/opcua/client.hpp
+++ b/modules/opcua/include/rmvl/opcua/client.hpp
@@ -222,7 +222,7 @@ public:
 
     /**
      * @brief 直接以底层数据调用指定对象节点中的方法
-     * 
+     *
      * @param[in] obj_nd 对象节点
      * @param[in] name 方法名
      * @param[in] args 方法的所有传入参数
@@ -315,7 +315,7 @@ public:
      * @param[in] period 定时器周期，单位：毫秒 `ms`
      * @param[in] callback 定时器回调函数
      */
-    RMVL_W ClientTimer(ClientView cv, double period, std::function<void(ClientView)> callback);
+    RMVL_W ClientTimer(ClientView cv, double period, std::function<void()> callback);
 
     //! @cond
     ClientTimer(const ClientTimer &) = delete;
@@ -332,9 +332,9 @@ public:
     RMVL_W void cancel();
 
 private:
-    ClientView _cv;                      //!< 客户端视图
-    std::function<void(ClientView)> _cb; //!< 定时器回调函数
-    uint64_t _id{};                      //!< 定时器 ID
+    ClientView _cv;            //!< 客户端视图
+    std::function<void()> _cb; //!< 定时器回调函数
+    uint64_t _id{};            //!< 定时器 ID
 };
 
 //! @} opcua

--- a/modules/opcua/include/rmvl/opcua/variable.hpp
+++ b/modules/opcua/include/rmvl/opcua/variable.hpp
@@ -150,14 +150,14 @@ public:
      */
     template <typename Tp, typename DecayT = typename std::decay_t<Tp>, typename = std::enable_if_t<std::is_fundamental_v<DecayT>>>
     RMVL_W_SUBST("V")
-    Variable(Tp val) : access_level(3U), _value(val), _data_type(DataType(typeid(DecayT))), _size(1) {}
+    Variable(Tp val) : _value(val), _data_type(DataType(typeid(DecayT))), _size(1) {}
 
     /**
      * @brief 字符串构造
      *
      * @param[in] str 字符串
      */
-    RMVL_W Variable(const std::string &str) : access_level(3U), _value(str), _data_type(DataType(typeid(std::string))), _size(1) {}
+    RMVL_W Variable(const std::string &str) : _value(str), _data_type(DataType(typeid(std::string))), _size(1) {}
 
     /**
      * @brief 字符串字面量构造
@@ -176,7 +176,7 @@ public:
      */
     template <typename Tp, typename Enable = std::enable_if_t<std::is_fundamental_v<Tp> && !std::is_same_v<bool, Tp>>>
     RMVL_W_SUBST("V_List")
-    Variable(const std::vector<Tp> &arr) : access_level(3U), _value(arr), _data_type(DataType(typeid(Tp))), _size(static_cast<UA_UInt32>(arr.size())) {}
+    Variable(const std::vector<Tp> &arr) : _value(arr), _data_type(DataType(typeid(Tp))), _size(static_cast<UA_UInt32>(arr.size())) {}
 
     /**
      * @brief 从变量类型创建新的变量节点
@@ -257,7 +257,7 @@ public:
     RMVL_W inline uint32_t size() const { return _size; }
 
 private:
-    explicit Variable(const VariableType &vtype) : access_level(3U), _type(vtype), _value(vtype.data()), _data_type(vtype.getDataType()), _size(vtype.size()) {}
+    explicit Variable(const VariableType &vtype) : _type(vtype), _value(vtype.data()), _data_type(vtype.getDataType()), _size(vtype.size()) {}
 
 public:
     //! 命名空间索引，默认为 `1`
@@ -283,7 +283,7 @@ public:
     //! 变量的描述
     RMVL_W_RW std::string description{};
     //! 访问性
-    RMVL_W_RW uint8_t access_level{};
+    RMVL_W_RW uint8_t access_level{3U};
 
 private:
     //! 变量类型

--- a/modules/opcua/src/client.cpp
+++ b/modules/opcua/src/client.cpp
@@ -376,13 +376,13 @@ bool ClientView::write(const NodeId &nd, const Variable &val) const { return cli
 
 /////////////////////// 客户端定时器 ///////////////////////
 
-static void timer_cb(UA_Client *p_server, void *data)
+static void timer_cb(UA_Client *, void *data)
 {
-    auto &func = *reinterpret_cast<std::function<void(ClientView)> *>(data);
-    func(p_server);
+    auto &func = *reinterpret_cast<std::function<void()> *>(data);
+    func();
 }
 
-ClientTimer::ClientTimer(ClientView cv, double period, std::function<void(ClientView)> callback) : _cv(cv), _cb(callback)
+ClientTimer::ClientTimer(ClientView cv, double period, std::function<void()> callback) : _cv(cv), _cb(callback)
 {
     auto status = UA_Client_addRepeatedCallback(_cv.get(), timer_cb, &_cb, period, &_id);
     if (status != UA_STATUSCODE_GOOD)

--- a/modules/opcua/test/test_opcua_client.cpp
+++ b/modules/opcua/test/test_opcua_client.cpp
@@ -227,7 +227,7 @@ TEST(OPC_UA_Client, timer_test)
     std::this_thread::sleep_for(10ms);
     rm::Client cli("opc.tcp://127.0.0.1:5015");
     int times{};
-    auto timer = rm::ClientTimer(cli, 10, [&](rm::ClientView) { times++; });
+    auto timer = rm::ClientTimer(cli, 10, [&]() { times++; });
     std::this_thread::sleep_for(60ms);
     cli.spinOnce();
     std::this_thread::sleep_for(60ms);


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [ ] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- OPC UA 客户端定时器 `rm::ClientTimer` 回调函数的传入参数移除客户端视图 `rm::ClientView`，能一定程度避免客户端嵌套处理异步事件的错误写法
- `rm::Variable` 的访问权限默认改为 `3U`，即 `rm::VARIABLE_READ | rm::VARIABLE_WRITE`
