### PR TITLE
更新 OPC UA 字符串字面量到 Variable 转换构造函数的写法

### DIFF
--- a/modules/opcua/include/rmvl/opcua/variable.hpp
+++ b/modules/opcua/include/rmvl/opcua/variable.hpp
@@ -166,7 +166,7 @@ public:
      * @param[in] str 字符串
      */
     template <std::size_t N>
-    Variable(const char (&str)[N]) : Variable(std::string(str, N)) {}
+    Variable(const char (&str)[N]) : Variable(std::string(str)) {}
 
     /**
      * @brief 列表构造
@@ -367,8 +367,8 @@ struct RMVL_EXPORTS_W_AG DataSourceVariable
     RMVL_W_RW std::string display_name{};
     //! 变量的描述
     RMVL_W_RW std::string description{};
-    //! 访问性
-    RMVL_W_RW uint8_t access_level{};
+    //! 访问性，默认为只读
+    RMVL_W_RW uint8_t access_level{1U};
 
     /**
      * @brief 数据源 Read 回调函数

--- a/modules/opcua/test/test_opcua_client.cpp
+++ b/modules/opcua/test/test_opcua_client.cpp
@@ -198,11 +198,13 @@ TEST(OPC_UA_ClientTest, event_monitor)
     srv.addEventTypeNode(etype);
     rm::Client cli("opc.tcp://127.0.0.1:5010");
 
-    std::string source_name;
+    std::string source_name{};
+    std::string messgae{};
     int aaa{};
-    cli.monitor({"SourceName", "aaa"}, [&](rm::ClientView, const rm::Variables &fields) {
-        source_name = fields[0].cast<std::string>();
-        aaa = fields[1];
+    cli.monitor({"Message", "SourceName", "aaa"}, [&](rm::ClientView, const rm::Variables &fields) {
+        messgae = fields[0].cast<std::string>();
+        source_name = fields[1].cast<std::string>();
+        aaa = fields[2];
     });
     // 触发事件
     auto event = rm::Event::makeFrom(etype);


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [ ] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

原先
```cpp
rm::Variable v1 = std::string("xxx");
```
和
```cpp
rm::Variable v2 = "xxx";
```
在经过 `v1 == v2` 的比较之后，返回的是 `false`，原因是字符串字面量到 `rm::Variable` 的构造函数的字符串长度是字符串字面量数组长度，而非字符串长度（区别在于是否考虑尾置 `\0`），现予以统一。