### PR TITLE
OPC UA 模块中，单元素的 vector 不再会被推导为标量类型

### DIFF
--- a/modules/opcua/include/rmvl/opcua/subscriber.hpp
+++ b/modules/opcua/include/rmvl/opcua/subscriber.hpp
@@ -37,7 +37,7 @@ struct RMVL_EXPORTS_W_AG FieldMetaData final
      *
      * @param[in] val 变量，可参考 @ref rm::Variable
      */
-    static FieldMetaData makeFrom(const Variable &val) { return {val.browse_name, val.getDataType(), val.size() == 1 ? -1 : 1, val.ns}; }
+    static FieldMetaData makeFrom(const Variable &val) { return {val.browse_name, val.getDataType(), val.size() == -1 ? -1 : 1, val.ns}; }
 
     //! 字段名称
     RMVL_W_RW std::string name;

--- a/modules/opcua/include/rmvl/opcua/variable.hpp
+++ b/modules/opcua/include/rmvl/opcua/variable.hpp
@@ -44,14 +44,14 @@ public:
      */
     template <typename Tp, typename DecayT = typename std::decay_t<Tp>, typename = std::enable_if_t<std::is_fundamental_v<DecayT>>>
     RMVL_W_SUBST("VT")
-    VariableType(Tp val) : _value(val), _data_type(DataType(typeid(DecayT))), _size(1) {}
+    VariableType(Tp val) : _value(val), _data_type(DataType(typeid(DecayT))), _size(-1) {}
 
     /**
      * @brief 字符串构造，设置默认值
      *
      * @param[in] str 字符串
      */
-    RMVL_W VariableType(const std::string &str) : _value(str), _data_type(DataType(typeid(std::string))), _size(1) {}
+    RMVL_W VariableType(const std::string &str) : _value(str), _data_type(DataType(typeid(std::string))), _size(-1) {}
 
     /**
      * @brief 字符串字面量构造
@@ -107,11 +107,11 @@ public:
     //! 获取数据类型
     RMVL_W inline DataType getDataType() const { return _data_type; }
 
-    //! 判断变量类型节点是否为空
+    //! 判断变量类型节点是否为空 @note 未初始化、空列表则为空
     RMVL_W constexpr bool empty() const { return _size == 0; }
 
-    //! 获取大小 @note 未初始化则返回 `0`
-    RMVL_W inline uint32_t size() const { return _size; }
+    //! 获取大小 @note 未初始化、空列表则返回 `0`，标量则返回 `-1`
+    RMVL_W inline int size() const { return _size; }
 
     //! 命名空间索引，默认为 `1`
     RMVL_W_RW uint16_t ns{1U};
@@ -142,7 +142,7 @@ private:
     //! 数据类型
     DataType _data_type{};
     //! 数据大小
-    uint32_t _size{};
+    int _size{};
 };
 
 //! OPC UA 变量
@@ -159,14 +159,14 @@ public:
      */
     template <typename Tp, typename DecayT = typename std::decay_t<Tp>, typename = std::enable_if_t<std::is_fundamental_v<DecayT>>>
     RMVL_W_SUBST("V")
-    Variable(Tp val) : _value(val), _data_type(DataType(typeid(DecayT))), _size(1) {}
+    Variable(Tp val) : _value(val), _data_type(DataType(typeid(DecayT))), _size(-1) {}
 
     /**
      * @brief 字符串构造
      *
      * @param[in] str 字符串
      */
-    RMVL_W Variable(const std::string &str) : _value(str), _data_type(DataType(typeid(std::string))), _size(1) {}
+    RMVL_W Variable(const std::string &str) : _value(str), _data_type(DataType(typeid(std::string))), _size(-1) {}
 
     /**
      * @brief 字符串字面量构造
@@ -222,7 +222,7 @@ public:
      */
     RMVL_W bool operator!=(const Variable &val) const { return !(*this == val); }
 
-    //! 判断变量节点是否为空
+    //! 判断变量节点是否为空 @note 未初始化、空列表则为空
     RMVL_W bool empty() const { return _size == 0; }
 
     /**
@@ -271,8 +271,8 @@ public:
     //! 获取形如 `UA_TYPES_<xxx>` 的数据类型
     RMVL_W inline DataType getDataType() const { return _data_type; }
 
-    //! 获取大小 @note 未初始化则返回 `0`
-    RMVL_W inline uint32_t size() const { return _size; }
+    //! 获取大小 @note 未初始化、空列表则返回 `0`，标量则返回 `-1`
+    RMVL_W inline int size() const { return _size; }
 
 private:
     explicit Variable(const VariableType &vtype) : _type(vtype), _value(vtype.data()), _data_type(vtype.getDataType()), _size(vtype.size()) {}
@@ -315,7 +315,7 @@ private:
     //! 数据类型
     DataType _data_type{};
     //! 数据大小
-    uint32_t _size{};
+    int _size{};
 };
 
 /**

--- a/modules/opcua/src/helper.cpp
+++ b/modules/opcua/src/helper.cpp
@@ -85,7 +85,7 @@ bool Variable::operator==(const Variable &val) const
         return false;
     if (_size != val._size)
         return false;
-    if (_size == 1)
+    if (_size == -1)
     {
         switch (_data_type)
         {
@@ -155,7 +155,7 @@ UA_Variant cvtVariable(const Variable &val) noexcept
     const std::any &data = val.data();
 
     UA_Variant p_val;
-    if (val.size() == 1)
+    if (val.size() == -1)
     {
         switch (val.getDataType())
         {
@@ -372,7 +372,7 @@ UA_Variant cvtVariable(const VariableType &vtype) noexcept
 
     UA_Variant p_val;
     UA_Variant_init(&p_val);
-    if (vtype.size() == 1)
+    if (vtype.size() == -1)
     {
         switch (vtype.getDataType())
         {

--- a/modules/opcua/src/server.cpp
+++ b/modules/opcua/src/server.cpp
@@ -154,7 +154,7 @@ NodeId Server::addVariableTypeNode(const VariableType &vtype)
     // 设置属性
     attr.value = variant;
     attr.dataType = variant.type->typeId;
-    attr.valueRank = vtype.size() == 1 ? UA_VALUERANK_SCALAR : 1;
+    attr.valueRank = vtype.size() == -1 ? UA_VALUERANK_SCALAR : 1;
     if (attr.valueRank != UA_VALUERANK_SCALAR)
     {
         attr.arrayDimensionsSize = variant.arrayDimensionsSize;
@@ -187,7 +187,7 @@ NodeId Server::addVariableNode(const Variable &val, const NodeId &parent_nd) noe
     attr.value = variant;
     attr.dataType = variant.type->typeId;
     attr.accessLevel = val.access_level;
-    attr.valueRank = val.size() == 1 ? UA_VALUERANK_SCALAR : 1;
+    attr.valueRank = val.size() == -1 ? UA_VALUERANK_SCALAR : 1;
     if (attr.valueRank != UA_VALUERANK_SCALAR)
     {
         attr.arrayDimensionsSize = variant.arrayDimensionsSize;

--- a/modules/opcua/test/test_opcua_addrspace.cpp
+++ b/modules/opcua/test/test_opcua_addrspace.cpp
@@ -20,23 +20,23 @@ TEST(OPC_UA_AddressSpace, Variable)
 {
     // 单值构造
     rm::Variable val1 = 42;
-    EXPECT_EQ(val1.size(), 1);
+    EXPECT_EQ(val1.size(), -1);
     EXPECT_EQ(val1.getDataType(), rm::tpInt32);
 
     rm::Variable val2 = 3.1415;
-    EXPECT_EQ(val2.size(), 1);
+    EXPECT_EQ(val2.size(), -1);
     EXPECT_EQ(val2.getDataType(), rm::tpDouble);
 
     rm::Variable val3 = false;
-    EXPECT_EQ(val3.size(), 1);
+    EXPECT_EQ(val3.size(), -1);
     EXPECT_EQ(val3.getDataType(), rm::tpBoolean);
 
     rm::Variable val4 = "test";
-    EXPECT_EQ(val4.size(), 1);
+    EXPECT_EQ(val4.size(), -1);
     EXPECT_EQ(val4.getDataType(), rm::tpString);
 
     rm::Variable val5 = std::string("test");
-    EXPECT_EQ(val5.size(), 1);
+    EXPECT_EQ(val5.size(), -1);
     EXPECT_EQ(val5.getDataType(), rm::tpString);
 
     // 列表构造
@@ -51,6 +51,10 @@ TEST(OPC_UA_AddressSpace, Variable)
     rm::Variable arr3 = std::vector{1, 2, 3};
     EXPECT_EQ(arr3.size(), 3);
     EXPECT_EQ(arr3.getDataType(), rm::tpInt32);
+
+    rm::Variable arr4 = {1};
+    EXPECT_EQ(arr4.size(), 1);
+    EXPECT_EQ(arr4.getDataType(), rm::tpInt32);
 
     // 单值比较
     EXPECT_EQ(val1, 42);
@@ -69,23 +73,23 @@ TEST(OPC_UA_AddressSpace, VariableType)
 {
     // 单值构造
     rm::VariableType vt1 = 42;
-    EXPECT_EQ(vt1.size(), 1);
+    EXPECT_EQ(vt1.size(), -1);
     EXPECT_EQ(vt1.getDataType(), rm::tpInt32);
 
     rm::VariableType vt2 = 3.1415;
-    EXPECT_EQ(vt2.size(), 1);
+    EXPECT_EQ(vt2.size(), -1);
     EXPECT_EQ(vt2.getDataType(), rm::tpDouble);
 
     rm::VariableType vt3 = false;
-    EXPECT_EQ(vt3.size(), 1);
+    EXPECT_EQ(vt3.size(), -1);
     EXPECT_EQ(vt3.getDataType(), rm::tpBoolean);
 
     rm::VariableType vt4 = "test";
-    EXPECT_EQ(vt4.size(), 1);
+    EXPECT_EQ(vt4.size(), -1);
     EXPECT_EQ(vt4.getDataType(), rm::tpString);
 
     rm::VariableType vt5 = std::string("test");
-    EXPECT_EQ(vt5.size(), 1);
+    EXPECT_EQ(vt5.size(), -1);
     EXPECT_EQ(vt5.getDataType(), rm::tpString);
 
     // 列表构造


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 原先的单一元素的 `std::vector` 会被推导为标量类型，例如
  ```cpp
  std::vector<int> arr = {1};
  rm::Variable v = arr;
  ```
  会被推导为和 `rm::Variable v = 1;` 相同的含义，现予以修正
- 修改 `rm::Variable` 和 `rm::VariableType` 的 `size()` 成员方法，标量类型的 `size()` 返回值为 `-1`，`0` 表示未初始化以及空 `vector` 的情况。