### PR TITLE
修改反射与 Socket 相关文档

### DIFF
--- a/3rdparty/fmt/CMakeLists.txt
+++ b/3rdparty/fmt/CMakeLists.txt
@@ -7,14 +7,31 @@ project(
   LANGUAGES CXX
 )
 
-rmvl_add_module(fmt)
+aux_source_directory(src fmt_src)
+
+add_library(fmt ${fmt_src})
+
+target_include_directories(
+  fmt PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${RMVL_INCLUDE_INSTALL_PATH}>
+)
+
+install(
+  TARGETS fmt
+  EXPORT RMVLModules
+  ARCHIVE DESTINATION ${RMVL_LIB_INSTALL_PATH}
+  LIBRARY DESTINATION ${RMVL_LIB_INSTALL_PATH}
+)
+
+install(
+  DIRECTORY include/fmt
+  DESTINATION ${RMVL_INCLUDE_INSTALL_PATH}
+)
 
 if(BUILD_TESTS)
-  rmvl_add_exe(
-    rmvl_fmt_test
-    SOURCES test/test_fmt.cpp
-    DEPENDS fmt
-  )
+  add_executable(rmvl_fmt_test test/test_fmt.cpp)
+  target_link_libraries(rmvl_fmt_test PRIVATE fmt)
   add_test(FMT.str ${CMAKE_BINARY_DIR}/bin/rmvl_fmt_test)
 endif()
   

--- a/3rdparty/json/CMakeLists.txt
+++ b/3rdparty/json/CMakeLists.txt
@@ -7,4 +7,20 @@ project(
   LANGUAGES CXX
 )
 
-rmvl_add_module(json INTERFACE)
+add_library(json INTERFACE)
+
+target_include_directories(
+  json INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${RMVL_INCLUDE_INSTALL_PATH}>
+)
+
+install(
+  TARGETS json
+  EXPORT RMVLModules
+)
+
+install(
+  DIRECTORY include/nlohmann
+  DESTINATION ${RMVL_INCLUDE_INSTALL_PATH}
+)

--- a/doc/intro.markdown
+++ b/doc/intro.markdown
@@ -11,7 +11,7 @@ RMVL 起源于 SRVL（SCUT Robotlab Vision Library——华南理工大学机器
 
 - **1.x** —— *2021.10* 发布<span style="color: green">（未开源）</span>，主要针对 RoboMaster 2021 赛季步兵、英雄机器人代码混乱的情况进行设计，初步尝试了使用抽象工厂设计模式来设计代码架构，届时，SRVL 开发者和使用者的不同需求需要在 SRVL 编译过程中修改编译选项。
 - **2.x** —— *2022.01* 发布<span style="color: green">（未开源）</span>，使用抽象工厂设计模式后出现了维护困难的情况，包括但不限于多个 @ref function_modules 共同组合，导致产生非常多的派生工厂，此版本针对这一弊端移除了原先所有的设计模式，各功能模块仅单独存在，不再另外设置组合或其他强依赖关系。此外， **2.x** 相较于 **1.x** 添加了全新的内容： @ref group 。
-- **3.x** —— *2022.08* 发布<span style="color: green">（未开源）</span>，架构、功能进一步完善。在开发上，添加了 CI/CD 自动化构建测试工具，使用 GoogleTest 为已有的组件、模块添加了单元测试，使用 benchmark 为部分功能添加了性能基准测试；在功能上，移除原先所有的 `group` 组件，重定义并完善了 `group` 组件所应当具备的功能，后续在此系列代码基础上，完成了 **RM2023 版整车状态估计** ；在使用上，顶层模块与视觉库完全分离，涉及到各个功能开启或关闭的逻辑功能将设置在顶层模块，这一部分内容由用户自行实现。此外，该版本完善了 CMake 的项目构建方式，并且可通过 `make install/uninstall` 完成编译安装、卸载。
+- **3.x** —— *2022.08* 发布<span style="color: green">（未开源）</span>，架构、功能进一步完善。在开发上，添加了 CI/CD 自动化构建测试工具，使用 GoogleTest 为已有的组件、模块添加了单元测试，使用 benchmark 为部分功能添加了性能基准测试；在功能上，移除原先所有的 @ref group ，重定义并完善了 @ref group 所应当具备的功能，后续在此系列代码基础上，完成了 **RM2023 版整车状态估计** ；在使用上，顶层模块与视觉库完全分离，涉及到各个功能开启或关闭的逻辑功能将设置在顶层模块，这一部分内容由用户自行实现。此外，该版本完善了 CMake 的项目构建方式，并且可通过 `make install/uninstall` 完成编译安装、卸载。
 - **4.x** —— *2023.09* 发布<span style="color: green">（已开源）</span>，并登陆 [Github](https://github.com/cv-rmvl/rmvl) 平台，更名 RMVL 以追求更加广泛的使用场景。并发布了 **RMVL 1.x** 系列版本，该系列彻底形成了面向对象迭代器设计模式与责任链设计模式相互结合的代码架构，同时将原先的 CI/CD 流水线迁移至 Github Actions。 **4.x** 版本在设计之初主要为了简化数据组件的开发，移除了不属于 @ref data_components 管理的，但在 @ref function_modules 中被设置的信息。此外还为各个 @ref function_modules 加入了 `XxxInfo` 的信息类。该版本首次加入命名空间 `rm`，避免了与其他库命名冲突的情况。此外，该版本极大程度简化并统一了参数模块的定义方式，将原先繁琐的参数定义、加载的功能使用自定义的参数文件 `*.para` 以及一组 CMake 函数 `rmvl_generate_para` 自动完成 C++ 代码生成与文档注解生成，为了更进一步简化参数模块的设计，RMVL 提供了 Visual Studio Code 的插件，为 `*.para` 文件提供语法高亮、代码提示、悬浮提示与代码块，并为 RMVL 中的部分函数与宏提供了代码提示、悬浮提示与代码块。
 - **RMVL 2.x** —— *2024.09* 发布<span style="color: green">（已开源）</span>，在功能上，该系列首次加入了 Python 支持，可参考 @ref tutorials_python ，此外还为 Windows 用户提供了 MSVC 编译器的支持，使用 CPack 工具，为 Windows 以及 Debian 系 Linux 发行版制作安装包。在架构上，新增 @ref algorithm ，将原先 @ref core 中的各类算法迁移至该模块。新增 @ref io ，提供跨平台的 I/O 协程设施，以及同步、异步的串口通信、进程间通信等内容，并提供了异步的 HTTP Web 后端框架。
 
@@ -24,7 +24,7 @@ RMVL 为硬件设备二次开发、网络通信、串口通信以及运动、控
 - 涉及 RM 的步兵机器人、英雄机器人、哨兵机器人和空中机器人 4 类射击型机器人的绝大部分功能
 - 涉及 RM 其余兵种的部分识别算法功能
 
-该代码库易于维护，说明文档丰富且齐全， @ref extra_modules 中所有的模块均已解耦，包括由特征 `feature`、特征组合 `combo`、追踪器 `tracker` 和序列组 `group` 组成的 **数据组件** ，由检测和识别模块 `detector`、补偿模块 `compensator`、目标预测模块 `predictor` 和决策模块 `decider` 组成的 **功能模块** ，这些模块分布在项目的 <span style="color: red">extra</span> 文件夹中。此外如上文所说，RMVL 还涉及到其余有关数据结构与算法、硬件设备二次开发库等内容，这些内容作为主要模块分布在项目的 <span style="color: red">modules</span> 文件夹中。
+该代码库易于维护，说明文档丰富且齐全， @ref extra_modules 中所有的模块均已解耦，包括由特征 feature、特征组合 combo、追踪器 tracker 和序列组 group 组成的 **数据组件** ，由检测和识别模块 detector、补偿模块 compensator、目标预测模块 predictor 和 decider 组成的 **功能模块** ，这些模块分布在项目的 <span style="color: red">extra</span> 文件夹中。此外如上文所说，RMVL 还涉及到其余有关数据结构与算法、硬件设备二次开发库等内容，这些内容作为主要模块分布在项目的 <span style="color: red">modules</span> 文件夹中。
 
 ------------
 
@@ -49,6 +49,8 @@ RMVL 具有模块化结构，这意味着该软件包包含了多个共享或静
 
   点击[此处](@ref tutorial_install)可以安装以上相机的 SDK
   
+- @ref io (**io**) —— 包含跨平台的 I/O 协程设施，以及同步、异步的串口通信、进程间通信等内容，并提供了异步的 HTTP Web 后端框架。
+
 - @ref ml (**ml**)， @ref opcua (**opcua**)
 
 - ... 以及其他包含在 `modules` 文件夹中的模块。
@@ -57,13 +59,13 @@ RMVL 具有模块化结构，这意味着该软件包包含了多个共享或静
 
 #### 数据组件 {#data_components}
 
-@ref feature (**feature**) —— RMVL 最基本的用于存储的数据结构，代表图像中的一个封闭曲线（轮廓、简单封闭图形）。开发中，轮廓通常可以使用 **OpenCV** @cite opencv_library 中的 `cv::findContours` 函数来获取，简单封闭图形可通过 **OpenCV** 中的 `imgproc` 模块提供的各类函数接口来进行获取，例如最小外接矩形 `cv::minAreaRect`、最小包络三角 `cv::minEnclosingTriangle` 等，提取到的对象 `cv::RotatedRect` 或一个 `cv::OutputArray` 等内容可由开发者自行转化成 `feature` 有用的信息（一般是通过 `feature` 的构造函数完成）。此外 RMVL 提供了默认 `feature`，即 rm::DefaultFeature ，用于表示无轮廓的信息，一般是一个角点。
+@ref feature (**feature**) —— RMVL 最基本的用于存储的数据结构，代表图像中的一个封闭曲线（轮廓、简单封闭图形）。开发中，轮廓通常可以使用 **OpenCV** @cite opencv_library 中的 `cv::findContours` 函数来获取，简单封闭图形可通过 **OpenCV** 中的 `imgproc` 模块提供的各类函数接口来进行获取，例如最小外接矩形 `cv::minAreaRect`、最小包络三角 `cv::minEnclosingTriangle` 等，提取到的对象 `cv::RotatedRect` 或一个 `cv::OutputArray` 等内容可由开发者自行转化成 feature 有用的信息（一般是通过 feature 的构造函数完成）。此外 RMVL 提供了默认 feature，即 rm::DefaultFeature ，用于表示无轮廓的信息，一般是一个角点。
 
-@ref combo (**combo**) —— 这种类型的组件由一系列特征组成，并使用 `std::vector<feature::ptr>` 来存储它们，特征的数量通常不会太多，并且这类特征在物理空间中通常是刚性的，即特征之间大致具备尺度不变的特点。开发中，一般会使用若干特征以及附带信息用于构造 `combo` 的派生对象。此外 RMVL 提供了默认 `combo`，即 rm::DefaultCombo ，用于表示单独的无关联的 `feature`。
+@ref combo (**combo**) —— 这种类型的组件由一系列特征组成，并使用 `std::vector<feature::ptr>` 来存储它们，特征的数量通常不会太多，并且这类特征在物理空间中通常是刚性的，即特征之间大致具备尺度不变的特点。开发中，一般会使用若干特征以及附带信息用于构造 combo 的派生对象。此外 RMVL 提供了默认 combo，即 rm::DefaultCombo ，用于表示单独的无关联的 feature。
 
-@ref tracker (**tracker**) —— `tracker` 是在时间上包含了许多相同物理特性的 `combo`，从而形成一个 `combo` 的时间序列，在 RMVL 中，则通过使用 `std::deque<combo::ptr>` 来表示这个时间序列。在功能上，`tracker` 不仅表示了不同时间下相同的 `combo` 的相关信息，还能处理在某个时间点上获取到不正确的 `combo` 的异常情况。此外 RMVL 提供了默认 `tracker`，即 rm::DefaultTracker ，用于表示无需时间序列信息的一组 `combo`。
+@ref tracker (**tracker**) —— tracker 是在时间上包含了许多相同物理特性的 combo，从而形成一个 combo 的时间序列，在 RMVL 中，则通过使用 `std::deque<combo::ptr>` 来表示这个时间序列。在功能上，tracker 不仅表示了不同时间下相同的 combo 的相关信息，还能处理在某个时间点上获取到不正确的 combo 的异常情况。此外 RMVL 提供了默认 tracker，即 rm::DefaultTracker ，用于表示无需时间序列信息的一组 combo。
 
-@ref group (**group**) —— 如果多个追踪器在物理空间上具有一定的相关性，比如共享轴旋转、刚性连接等属性，它们可以一起形成一个序列组 `group`，从而能够表示更加高级的物理信息。序列组使用 `std::vector<tracker::ptr>` 来存储这些追踪器。此外 RMVL 提供了默认 `group`，即 rm::DefaultGroup ，用于表示若干无相关性的一组 `tracker`，即退化成了 `std::vector<tracker::ptr>`。
+@ref group (**group**) —— 如果多个追踪器在物理空间上具有一定的相关性，比如共享轴旋转、刚性连接等属性，它们可以一起形成一个序列组 group，从而能够表示更加高级的物理信息。序列组使用 `std::vector<tracker::ptr>` 来存储这些追踪器。此外 RMVL 提供了默认 group，即 rm::DefaultGroup ，用于表示若干无相关性的一组 tracker，即退化成了 `std::vector<tracker::ptr>`。
 
 #### 功能模块 {#function_modules}
 
@@ -73,7 +75,7 @@ RMVL 具有模块化结构，这意味着该软件包包含了多个共享或静
 
 @ref compensator (**compensator**) —— 补偿器通常是功能模块中的第一个用于修正数据组件的算法模块，<span style="color: green">主要在 RoboMaster 赛事中使用</span>。补偿器主要负责修正弹道下坠的影响。计算得到的子弹飞行时间 `tof` 以及补偿增量 `compensation` 均保存至补偿模块信息 `rm::CompensateInfo` 中。
 
-@ref predictor (**predictor**) —— 对于需要考虑目标追踪或存在较长通讯延迟的机器人而言，必须要引入目标预测环节，使得伺服机构能够恒定追踪、捕获目标，<span style="color: green">在 RoboMaster 赛事中一般用于保证弹丸能够准确击中敌方目标</span>。一般而言，每一个预测模块会针对特定的数据组件（派生的 `group` 对象）进行 2~3 种预测量类型的计算，包括动态响应预测量 `Kt`、静态响应预测量 `B`、射击延迟预测量 `Bs`，每种预测量类型都包含 9 种预测对象，每个预测对象之间对于 3 种预测量类型来说都是线性关系，例如在 @ref gyro_predictor 中对于 `ANG_Y` 预测对象的 3 种预测量都是单独计算的，这也便于后续的 **决策模块** 能够自由组合这些预测量。同样，计算得到的各类预测量均被保存至预测模块信息 `rm::PredictInfo` 中。
+@ref predictor (**predictor**) —— 对于需要考虑目标追踪或存在较长通讯延迟的机器人而言，必须要引入目标预测环节，使得伺服机构能够恒定追踪、捕获目标，<span style="color: green">在 RoboMaster 赛事中一般用于保证弹丸能够准确击中敌方目标</span>。一般而言，每一个预测模块会针对特定的数据组件（派生的 group 对象）进行 2~3 种预测量类型的计算，包括动态响应预测量 `Kt`、静态响应预测量 `B`、射击延迟预测量 `Bs`，每种预测量类型都包含 9 种预测对象，每个预测对象之间对于 3 种预测量类型来说都是线性关系，例如在 @ref gyro_predictor 中对于 `ANG_Y` 预测对象的 3 种预测量都是单独计算的，这也便于后续的 **决策模块** 能够自由组合这些预测量。同样，计算得到的各类预测量均被保存至预测模块信息 `rm::PredictInfo` 中。
   
 <center>
 

--- a/doc/tutorials/modules/tools/aggregate_reflect.md
+++ b/doc/tutorials/modules/tools/aggregate_reflect.md
@@ -169,12 +169,14 @@ void init() {
   我们通过一个例子来说明，并给出详细的运行步骤。
 
   ```cpp
+  #include <rmvl/core/util.hpp>
+
   struct X {
       int a{}, b{};
   };
 
   int main() {
-      std::cout << rm::size<X>() << std::endl;
+      std::cout << rm::reflect::size<X>() << std::endl;
       // 输出 2
   }
   ```
@@ -215,6 +217,7 @@ void for_each(const Tp &val, Callable &&f);
 下面给出一个例子
 
 ```cpp
+#include <iostream>
 #include <rmvl/core/util.hpp>
 
 struct X {
@@ -229,7 +232,7 @@ int main() {
     };
 
     X x{1, 3.1, "abc"};
-    rm::for_each(x, f);
+    rm::reflect::for_each(x, f);
 }
 ```
 
@@ -268,6 +271,7 @@ bool equal(const Tp &lhs, const Tp &rhs);
 下面给出一个例子
 
 ```cpp
+#include <iostream>
 #include <rmvl/core/util.hpp>
 
 struct X {

--- a/modules/io/CMakeLists.txt
+++ b/modules/io/CMakeLists.txt
@@ -4,7 +4,8 @@
 rmvl_generate_para(io)
 
 rmvl_add_module(io
-  DEPENDS core json fmt
+  DEPENDS core
+  EXTERNAL json fmt
 )
 
 # for glibc < 2.34

--- a/modules/io/include/rmvl/io/socket.hpp
+++ b/modules/io/include/rmvl/io/socket.hpp
@@ -30,9 +30,17 @@ using SocketFd = int;
 constexpr SocketFd INVALID_SOCKET_FD = -1;
 #endif
 
-//! IP 协议族
+/**
+ * @brief IP 协议族，包含 IPv4 和 IPv6 以及多播选项的相关定义
+ *
+ * @details
+ * - 在网络层，提供 ip::Networkv4 和 ip::Networkv6 类来表示 IPv4 和 IPv6 地址
+ * - 在传输层，提供 ip::tcp 和 ip::udp 命名空间，分别表示 TCP 和 UDP 协议
+ * - 提供多播选项的封装类，便于在 Socket 上设置多播相关选项
+ */
 namespace ip {
 
+//! 网络协议
 struct Protocol {
     //! 协议族
     int family{};
@@ -87,6 +95,7 @@ private:
     std::array<uint8_t, 16> _addr{}; //!< IPv6 地址
 };
 
+//! 多播
 namespace multicast {
 
 #ifdef _WIN32
@@ -149,7 +158,7 @@ Protocol v4();
 //! 构造端点，以表示 IPv6 TCP 协议
 Protocol v6();
 
-}; // namespace tcp
+} // namespace tcp
 
 //! UDP 协议
 namespace udp {
@@ -159,11 +168,11 @@ Protocol v4();
 //! 构造端点，以表示 IPv6 UDP 协议
 Protocol v6();
 
-}; // namespace udp
+} // namespace udp
 
 } // namespace ip
 
-// 接口驱动类型
+//! 接口驱动类型
 enum class NetworkInterfaceType : uint8_t {
     Ethernet, //!< 以太网
     Wireless, //!< 无线接口
@@ -171,10 +180,10 @@ enum class NetworkInterfaceType : uint8_t {
     Tunnel,   //!< 隧道接口
     Loopback, //!< `lo` 回环设备
     Other,    //!< 其他
-    Unknown,  //!< 未知类型
+    Unknown   //!< 未知类型
 };
 
-// 接口功能与状态标志
+//! 接口功能与状态标志
 struct NetworkInterfaceFlag {
     static constexpr uint8_t Up = 1 << 0;        //!< 接口已启用
     static constexpr uint8_t Broadcast = 1 << 1; //!< 支持广播


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 增加聚合类反射相关文档的命名空间
- `ip` 命名空间增加 details 注释
- `fmt` 与 `json` 改为 `EXTERNAL`，取消 `rmvl_` 的 CMake 前缀