### PR TITLE
增加 OpenCV 图像转换支持（模拟 cv_bridge）

### DIFF
--- a/modules/lpss/include/rmvl/lpss.hpp
+++ b/modules/lpss/include/rmvl/lpss.hpp
@@ -22,3 +22,4 @@
  */
 
 #include "lpss/node.hpp"
+#include "lpss/cv.hpp"

--- a/modules/lpss/include/rmvl/lpss/cv.hpp
+++ b/modules/lpss/include/rmvl/lpss/cv.hpp
@@ -1,0 +1,49 @@
+/**
+ * @file cv.hpp
+ * @author zhaoxi (535394140@qq.com)
+ * @brief OpenCV 消息转换定义
+ * @version 1.0
+ * @date 2026-01-28
+ *
+ * @copyright Copyright 2026 (c), zhaoxi
+ *
+ */
+
+#pragma once
+
+#include "rmvl/rmvl_modules.hpp"
+
+#ifdef HAVE_OPENCV
+
+#include <opencv2/core/mat.hpp>
+
+#include "rmvlmsg/sensor/image.hpp"
+
+namespace rm {
+
+//! @addtogroup lpss
+//! @{
+
+/**
+ * @brief 从 Image 消息转换为 cv::Mat
+ * 
+ * @param[in] img_msg Image 图像消息
+ * @return OpenCV 图像矩阵
+ */
+cv::Mat from_msg(const msg::Image &img_msg);
+
+/**
+ * @brief 从 cv::Mat 转换为 Image 消息
+ * 
+ * @param[in] img OpenCV 图像矩阵
+ * @param[in] encoding 图像编码格式，包括 "rgb8", "bgr8", "mono8", "mono16", "rgba8",
+ * "bgra8", "bayer_rggb8" 和 "bayer_bggr8"
+ * @return Image 图像消息
+ */
+msg::Image to_msg(cv::Mat img, std::string_view encoding);
+
+//! @} lpss
+
+} // namespace rm
+
+#endif

--- a/modules/lpss/include/rmvl/lpss/node.hpp
+++ b/modules/lpss/include/rmvl/lpss/node.hpp
@@ -22,10 +22,13 @@
 
 #include "details/node_rsd.hpp"
 
-namespace rm::lpss {
+namespace rm {
 
 //! @addtogroup lpss
 //! @{
+
+//! 轻量发布订阅服务框架命名空间，包含节点、发布者、订阅者等相关定义
+namespace lpss {
 
 /**
  * @brief 发布者代理
@@ -371,8 +374,10 @@ private:
 
 #endif
 
+} // namespace lpss
+
 //! @} lpss
 
-} // namespace rm::lpss
+} // namespace rm
 
 #include "details/node_impl.hpp"

--- a/modules/lpss/msg/sensor/Image.msg
+++ b/modules/lpss/msg/sensor/Image.msg
@@ -11,11 +11,11 @@ Header header # Header timestamp should be acquisition time of image
               # message associated with the image conflict
               # the behavior is undefined
 
-uint32 height # image height, that is, number of rows
-uint32 width  # image width, that is, number of columns
+int32 height # image height, that is, number of rows
+int32 width  # image width, that is, number of columns
 
 string encoding # Encoding of pixels -- channel meaning, ordering
-                  # contain "rgb8", "bgr8", "mono8", "mono16", "rgba8",
-                  # "bgra8", "bayer_rggb8", "bayer_bggr8",
-                  # "bayer_rggb16", "bayer_bggbr16", "yuv422", "yuv420"
-uint8[] data    # actual matrix data, size is (step * rows)
+                # contain "rgb8", "bgr8", "mono8", "mono16", "rgba8",
+                # "bgra8", "bayer_rggb8", "bayer_bggr8",
+                # "bayer_rggb16", "bayer_bggbr16", "yuv422", "yuv420"
+uint8[] data    # actual matrix data

--- a/modules/lpss/src/cv.cpp
+++ b/modules/lpss/src/cv.cpp
@@ -1,0 +1,57 @@
+/**
+ * @file cv.cpp
+ * @author zhaoxi (535394140@qq.com)
+ * @brief
+ * @version 1.0
+ * @date 2026-01-28
+ *
+ * @copyright Copyright 2026 (c), zhaoxi
+ *
+ */
+
+#include <unordered_set>
+
+#include "rmvl/lpss/cv.hpp"
+
+#ifdef HAVE_OPENCV
+
+namespace rm {
+
+cv::Mat from_msg(const msg::Image &img_msg) {
+    if (img_msg.data.empty()) {
+        return cv::Mat{};
+    }
+    if (img_msg.encoding == "mono8")
+        return cv::Mat(img_msg.height, img_msg.width, CV_8UC1, const_cast<uint8_t *>(img_msg.data.data())).clone();
+    else if (img_msg.encoding == "bgr8" || img_msg.encoding == "rgb8")
+        return cv::Mat(img_msg.height, img_msg.width, CV_8UC3, const_cast<uint8_t *>(img_msg.data.data())).clone();
+    else if (img_msg.encoding == "rgba8" || img_msg.encoding == "bgra8")
+        return cv::Mat(img_msg.height, img_msg.width, CV_8UC4, const_cast<uint8_t *>(img_msg.data.data())).clone();
+    else if (img_msg.encoding == "mono16")
+        return cv::Mat(img_msg.height, img_msg.width, CV_16UC1, const_cast<uint8_t *>(img_msg.data.data())).clone();
+    else if (img_msg.encoding == "bayer_rggb8")
+        return cv::Mat(img_msg.height, img_msg.width, CV_8UC1, const_cast<uint8_t *>(img_msg.data.data())).clone();
+    else if (img_msg.encoding == "bayer_bggr8")
+        return cv::Mat(img_msg.height, img_msg.width, CV_8UC1, const_cast<uint8_t *>(img_msg.data.data())).clone();
+    else
+        return cv::Mat{};
+}
+
+msg::Image to_msg(cv::Mat img, std::string_view encoding) {
+    static std::unordered_set<std::string> valid_encodings = {"rgb8", "bgr8", "mono8", "mono16", "rgba8", "bgra8", "bayer_rggb8", "bayer_bggr8"};
+    if (valid_encodings.find(std::string(encoding)) == valid_encodings.end())
+        return msg::Image{};
+
+    msg::Image img_msg{};
+    img_msg.height = img.rows;
+    img_msg.width = img.cols;
+    img_msg.encoding = encoding;
+    size_t data_size = img.total() * img.elemSize();
+    img_msg.data.resize(data_size);
+    std::memcpy(img_msg.data.data(), img.data, data_size);
+    return img_msg;
+}
+
+} // namespace rm
+
+#endif

--- a/samples/camera/mv/sample_mv_auto_calib.cpp
+++ b/samples/camera/mv/sample_mv_auto_calib.cpp
@@ -214,7 +214,7 @@ int main(int argc, char *argv[]) {
     int flags = 0;
     rm::MvCamera capture(rm::CameraConfig::create(rm::GrabMode::Continuous, rm::RetrieveMode::OpenCV));
 
-    int exposure{10000};
+    double exposure{10000};
     int gain{128};
     int r_gain{100};
     int g_gain{100};

--- a/samples/camera/mv/sample_mv_manual_calib.cpp
+++ b/samples/camera/mv/sample_mv_manual_calib.cpp
@@ -41,7 +41,7 @@ int main() {
     fs_mv_in["cameraMatrix"].isNone() ? void(0) : (fs_mv_in["cameraMatrix"] >> cameraMatrix);
     fs_mv_in["distCoeffs"].isNone() ? void(0) : (fs_mv_in["distCoeffs"] >> distCoeffs);
 
-    int exposure = 10000;
+    double exposure = 10000;
     int gain = 64;
     int r_gain = 100;
     int g_gain = 100;

--- a/samples/camera/mv/sample_mv_mono.cpp
+++ b/samples/camera/mv/sample_mv_mono.cpp
@@ -15,7 +15,7 @@ rm::MvCamera cap(rm::CameraConfig::create(rm::GrabMode::Continuous, rm::Retrieve
 
 void exposureCallBack(int pos, void *) {
     exposure = pos;
-    cap.set(rm::CameraProperties::exposure, exposure);
+    cap.set(rm::CameraProperties::exposure, static_cast<double>(exposure));
 }
 
 void gainCallBack(int pos, void *) {

--- a/samples/camera/mv/sample_mv_multi.cpp
+++ b/samples/camera/mv/sample_mv_multi.cpp
@@ -52,7 +52,7 @@ int main() {
     }
 
     capture.set(rm::CameraProperties::auto_exposure, false);
-    capture.set(rm::CameraProperties::exposure, exposure);
+    capture.set(rm::CameraProperties::exposure, static_cast<double>(exposure));
     capture.set(rm::CameraProperties::gain, gain);
     capture.set(rm::CameraProperties::auto_wb, false);
     capture.set(rm::CameraProperties::wb_rgain, r_gain);

--- a/samples/camera/mv/sample_mv_writer.cpp
+++ b/samples/camera/mv/sample_mv_writer.cpp
@@ -12,7 +12,7 @@ int main() {
         ERROR_("fail to read the image.");
     cv::VideoWriter writer("ts.avi", cv::VideoWriter::fourcc('F', 'L', 'V', '1'), 40, tmp.size());
 
-    int exposure = 1000;
+    double exposure = 1000;
     int gain = 64;
     int r_gain = 100;
     int g_gain = 100;


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

增加 OpenCV 图像转换支持 `from_msg` 以及 `to_msg`