### PR TITLE
增加 OpenCV 中部分类型的消息转换

### DIFF
--- a/modules/lpss/CMakeLists.txt
+++ b/modules/lpss/CMakeLists.txt
@@ -39,3 +39,8 @@ if(BUILD_PERF_TESTS)
     EXTERNAL benchmark::benchmark_main
   )
 endif(BUILD_PERF_TESTS)
+
+# ----------------------------------------------------------------------------
+#  Doxygen update
+# ----------------------------------------------------------------------------
+rmvl_update_doxygen_predefined("LPSS_CV_VERSION=99999") # Doxygen 设置为支持所有版本的 OpenCV，实际值在 cv.hpp 中定义

--- a/modules/lpss/include/rmvl/lpss/cv.hpp
+++ b/modules/lpss/include/rmvl/lpss/cv.hpp
@@ -15,8 +15,16 @@
 
 #ifdef HAVE_OPENCV
 
-#include <opencv2/core/mat.hpp>
+#include <opencv2/core/affine.hpp>
 
+#define LPSS_CV_VERSION CV_VERSION_MAJOR * 10000 + CV_VERSION_MINOR * 100 + CV_VERSION_REVISION
+#if LPSS_CV_VERSION >= 40501
+#include <opencv2/core/quaternion.hpp>
+#endif
+
+#include "rmvlmsg/geometry/point.hpp"
+#include "rmvlmsg/geometry/point32.hpp"
+#include "rmvlmsg/geometry/transform.hpp"
 #include "rmvlmsg/sensor/image.hpp"
 
 namespace rm {
@@ -24,23 +32,112 @@ namespace rm {
 //! @addtogroup lpss
 //! @{
 
+//! OpenCV 与 LPSS 消息转换命名空间
+namespace cvmsg {
+
+/**
+ * @brief 从 Point 消息转换为 cv::Point3d
+ *
+ * @param[in] pt_msg Point 消息对象
+ * @return cv::Point3d 表示的三维点对象
+ */
+cv::Point3d from_msg(const msg::Point &pt_msg);
+
+/**
+ * @brief 从 cv::Point3d 转换为 Point 消息
+ *
+ * @param[in] pt OpenCV 三维点对象
+ * @return Point 消息对象
+ */
+msg::Point to_msg(const cv::Point3d &pt);
+
+/**
+ * @brief 从 Point32 消息转换为 cv::Point3f
+ *
+ * @param[in] pt_msg Point32 消息对象
+ * @return cv::Point3f 表示的三维点对象
+ */
+cv::Point3f from_msg(const msg::Point32 &pt_msg);
+
+/**
+ * @brief 从 cv::Point3f 转换为 Point32 消息
+ *
+ * @param[in] pt OpenCV 三维点对象
+ * @return Point32 消息对象
+ */
+msg::Point32 to_msg(const cv::Point3f &pt);
+
+/**
+ * @brief 从 Vector3 消息转换为 cv::Vec3d
+ *
+ * @param[in] vec_msg Vector3 消息对象
+ * @return cv::Vec3d 表示的三维向量对象
+ */
+cv::Vec3d from_msg(const msg::Vector3 &vec_msg);
+
+/**
+ * @brief 从 cv::Vec3d 转换为 Vector3 消息
+ *
+ * @param[in] vec OpenCV 三维向量对象
+ * @return Vector3 消息对象
+ */
+msg::Vector3 to_msg(const cv::Vec3d &vec);
+
+#if LPSS_CV_VERSION >= 40501
+
+/**
+ * @brief 从 Quaternion 消息转换为 cv::Quatd
+ *
+ * @param[in] quat_msg Quaternion 消息对象
+ * @return cv::Quatd 表示的四元数对象
+ */
+cv::Quatd from_msg(const msg::Quaternion &quat_msg);
+
+/**
+ * @brief 从 cv::Quatd 转换为 Quaternion 消息
+ *
+ * @param[in] quat OpenCV 四元数对象
+ * @return Quaternion 消息对象
+ */
+msg::Quaternion to_msg(const cv::Quatd &quat);
+
+/**
+ * @brief 从 Transform 消息转换为 cv::Affine3d
+ *
+ * @param[in] tf_msg Transform 消息对象
+ * @return cv::Affine3d 表示的仿射变换对象
+ */
+cv::Affine3d from_msg(const msg::Transform &tf_msg);
+
+/**
+ * @brief 从 cv::Affine3d 转换为 Transform 消息
+ *
+ * @param[in] tf OpenCV 仿射变换对象
+ * @return Transform 消息对象
+ */
+msg::Transform to_msg(const cv::Affine3d &tf);
+
+#endif
+
 /**
  * @brief 从 Image 消息转换为 cv::Mat
- * 
+ *
  * @param[in] img_msg Image 图像消息
- * @return OpenCV 图像矩阵
+ * @return cv::Mat 表示的图像矩阵
  */
 cv::Mat from_msg(const msg::Image &img_msg);
 
 /**
  * @brief 从 cv::Mat 转换为 Image 消息
- * 
+ *
  * @param[in] img OpenCV 图像矩阵
  * @param[in] encoding 图像编码格式，包括 "rgb8", "bgr8", "mono8", "mono16", "rgba8",
  * "bgra8", "bayer_rggb8" 和 "bayer_bggr8"
  * @return Image 图像消息
  */
 msg::Image to_msg(cv::Mat img, std::string_view encoding);
+
+} // namespace cvmsg
 
 //! @} lpss
 

--- a/modules/lpss/src/cv.cpp
+++ b/modules/lpss/src/cv.cpp
@@ -15,7 +15,41 @@
 
 #ifdef HAVE_OPENCV
 
-namespace rm {
+namespace rm::cvmsg {
+
+cv::Point3d from_msg(const msg::Point &pt_msg) { return {pt_msg.x, pt_msg.y, pt_msg.z}; }
+
+msg::Point to_msg(const cv::Point3d &pt) { return {pt.x, pt.y, pt.z}; }
+
+cv::Point3f from_msg(const msg::Point32 &pt_msg) { return {pt_msg.x, pt_msg.y, pt_msg.z}; }
+
+msg::Point32 to_msg(const cv::Point3f &pt) { return {pt.x, pt.y, pt.z}; }
+
+cv::Vec3d from_msg(const msg::Vector3 &vec_msg) { return {vec_msg.x, vec_msg.y, vec_msg.z}; }
+
+msg::Vector3 to_msg(const cv::Vec3d &vec) { return {vec[0], vec[1], vec[2]}; }
+
+#if LPSS_CV_VERSION >= 40501
+
+cv::Quatd from_msg(const msg::Quaternion &quat_msg) { return {quat_msg.w, quat_msg.x, quat_msg.y, quat_msg.z}; }
+
+msg::Quaternion to_msg(const cv::Quatd &quat) { return {quat.w, quat.x, quat.y, quat.z}; }
+
+cv::Affine3d from_msg(const msg::Transform &tf_msg) {
+    cv::Quatd quat = from_msg(tf_msg.rotation);
+    cv::Vec3d trans = from_msg(tf_msg.translation);
+    return cv::Affine3d(quat.toRotMat3x3(), trans);
+}
+
+msg::Transform to_msg(const cv::Affine3d &tf) {
+    cv::Matx33d rot_mat = tf.rotation();
+    msg::Transform tf_msg{};
+    tf_msg.rotation = to_msg(cv::Quatd::createFromRotMat(rot_mat));
+    tf_msg.translation = to_msg(tf.translation());
+    return tf_msg;
+}
+
+#endif
 
 cv::Mat from_msg(const msg::Image &img_msg) {
     if (img_msg.data.empty()) {
@@ -55,6 +89,6 @@ msg::Image to_msg(cv::Mat img, std::string_view encoding) {
     return img_msg;
 }
 
-} // namespace rm
+} // namespace rm::cvmsg
 
 #endif


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 增加 `Point3d`、`Point3f`、`Vec3d`、`Quatd`、`Affine3d` 的消息转换，分别对应于 `Point`、`Point32`、`Vector3`、`Quaternion` 和 `Transform`
- 增加较高版本 OpenCV 版本的判定，并添加至 Doxygen 中