### PR TITLE
修复销毁逻辑和端点存储信息

### DIFF
--- a/modules/lpss/include/rmvl/lpss/details/node_rsd.hpp
+++ b/modules/lpss/include/rmvl/lpss/details/node_rsd.hpp
@@ -190,7 +190,7 @@ protected:
 //! 发现的发布者端点存储信息
 struct DiscoveredWriterStorageInfo {
     std::unordered_set<Guid, GuidHash> writers; //!< 相关的端点 GUID 列表
-    std::string_view msgtype;                   //!< 消息类型
+    std::string msgtype;                        //!< 消息类型
 };
 
 /**
@@ -239,7 +239,7 @@ protected:
 //! 发现的订阅者端点存储信息
 struct DiscoveredReaderStorageInfo {
     std::unordered_map<Guid, Locator, GuidHash> readers; //!< 相关的端点 GUID 与定位器映射表 [Guid: Locator]
-    std::string_view msgtype;                            //!< 消息类型
+    std::string msgtype;                                 //!< 消息类型
 };
 
 /**

--- a/modules/lpss/src/node_async.cpp
+++ b/modules/lpss/src/node_async.cpp
@@ -207,6 +207,8 @@ rm::async::Task<> Node::on_sigint() {
     co_await sig.wait();
     printf("\nReceived interrupt signal, stopping node...\n");
     sendStopMessage(_discovered_nodes, _local_writers, _local_readers);
+    _local_readers.clear();
+    _local_writers.clear();
     _ctx.stop();
 }
 
@@ -243,6 +245,8 @@ Node::Node(std::string_view name, uint8_t domain_id) : _rndp_port(7500 + domain_
 
 void Node::shutdown() noexcept {
     sendStopMessage(_discovered_nodes, _local_writers, _local_readers);
+    _local_readers.clear();
+    _local_writers.clear();
     _ctx.stop();
 }
 


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 添加本地发布者和订阅者在 `shutdown` 时的销毁逻辑
- 端点存储信息的 `string_view` 改为 `string`