### PR TITLE
image 消息类型 encoding 改为 uint8

### DIFF
--- a/doc/tutorials/modules/tutorial_rmvlmsg.md
+++ b/doc/tutorials/modules/tutorial_rmvlmsg.md
@@ -17,7 +17,7 @@ RMVL 消息描述文件（`*.msg`）用于定义消息的数据结构和字段�
 
 ### 2 内置消息类型
 
-以下是一些常用的内置消息类型，分为三个主要分组：`std`、`geometry` 和 `sensor`。用户可以根据需要在自定义的 `*.msg` 文件中引用这些内置消息类型。
+以下是一些常用的内置消息类型，分为四个主要分组：`std`、`geometry`、`sensor` 和 `viz`。用户可以根据需要在自定义的 `*.msg` 文件中引用这些内置消息类型。
 
 <div class="tabbed">
 
@@ -74,7 +74,7 @@ RMVL 消息描述文件（`*.msg`）用于定义消息的数据结构和字段�
     <td class="markdownTableBodyLeft"><code>Header</code></td>
     <td class="markdownTableBodyLeft"><div class="fragment">
       <div class="line"><span class="keywordtype">uint32</span> seq</div>
-      <div class="line"><span class="keywordtype">float64</span> stamp</div>
+      <div class="line"><span class="keywordtype">time</span> stamp</div>
       <div class="line"><span class="keywordtype">string</span> frame_id</div>
     </div></td>
     <td class="markdownTableBodyLeft">包含序列号、时间戳和坐标系 ID 的标准消息头</td>
@@ -115,27 +115,34 @@ RMVL 消息描述文件（`*.msg`）用于定义消息的数据结构和字段�
     <td class="markdownTableBodyLeft">表示字符串数据，底层采用 `std::string` 存储</td>
   </tr>
   <tr class="markdownTableRowEven">
+    <td class="markdownTableBodyLeft"><code>Time</code></td>
+    <td class="markdownTableBodyLeft"><div class="fragment">
+      <div class="line"><span class="keywordtype">time</span> data</div>
+    </div></td>
+    <td class="markdownTableBodyLeft">记录了自 1970 年 1 月 1 日以来的时间，一般采用毫秒时间戳</td>
+  </tr>
+  <tr class="markdownTableRowOdd">
     <td class="markdownTableBodyLeft"><code>UInt8</code></td>
     <td class="markdownTableBodyLeft"><div class="fragment">
       <div class="line"><span class="keywordtype">uint8</span> data</div>
     </div></td>
     <td class="markdownTableBodyLeft">表示 8 位无符号整数数据</td>
   </tr>
-  <tr class="markdownTableRowOdd">
+  <tr class="markdownTableRowEven">
     <td class="markdownTableBodyLeft"><code>UInt16</code></td>
     <td class="markdownTableBodyLeft"><div class="fragment">
       <div class="line"><span class="keywordtype">uint16</span> data</div>
     </div></td>
     <td class="markdownTableBodyLeft">表示 16 位无符号整数数据</td>
   </tr>
-  <tr class="markdownTableRowEven">
+  <tr class="markdownTableRowOdd">
     <td class="markdownTableBodyLeft"><code>UInt32</code></td>
     <td class="markdownTableBodyLeft"><div class="fragment">
       <div class="line"><span class="keywordtype">uint32</span> data</div>
     </div></td>
     <td class="markdownTableBodyLeft">表示 32 位无符号整数数据</td>
   </tr>
-  <tr class="markdownTableRowOdd">
+  <tr class="markdownTableRowEven">
     <td class="markdownTableBodyLeft"><code>UInt64</code></td>
     <td class="markdownTableBodyLeft"><div class="fragment">
       <div class="line"><span class="keywordtype">uint64</span> data</div>
@@ -326,6 +333,45 @@ RMVL 消息描述文件（`*.msg`）用于定义消息的数据结构和字段�
   <div class="line"><span class="keywordtype">string</span> robot_name</div>
   <div class="line"><span class="keywordtype">uint8</span>[4] ip</div>
   <div class="line"><span class="keyword">sensor/JointState</span> joint_state</div>
+  </div>
+
+- <b class="tab-title">viz 消息分组</b>
+
+  `viz` 消息用于表示可视化相关的数据，例如标记、路径和交互式控制，嵌套使用时<span style="color: red">需要</span>使用 `viz/` 前缀。
+
+  <div class="full_width_table">
+  <table class="markdownTable">
+  <tr class="markdownTableHead">
+    <th class="markdownTableHeadCenter">类型</th>
+    <th class="markdownTableHeadCenter">*.msg 定义</th>
+    <th class="markdownTableHeadCenter">描述</th>
+  </tr>
+  <tr class="markdownTableRowOdd">
+    <td class="markdownTableBodyLeft"><code>Marker</code></td>
+    <td class="markdownTableBodyLeft"><div class="fragment">
+      <div class="line"><span class="keyword">Header</span> header</div>
+      <div class="line"><span class="keywordtype">uint32</span> id</div>
+      <div class="line"><span class="keywordtype">uint8</span> type</div>
+      <div class="line"><span class="keywordtype">uint8</span> action</div>
+      <div class="line"><span class="keyword">geometry/Pose</span> pose</div>
+      <div class="line"><span class="keyword">geometry/Vector3</span> scale</div>
+      <div class="line"><span class="keyword">ColorRGBA</span> color</div>
+      <div class="line"><span class="keyword">geometry/Point</span>[] points</div>
+      <div class="line"><span class="keyword">ColorRGBA</span>[] colors</div>
+      <div class="line"></div>
+      <div class="line"><span class="keyword">geometry/Point</span>[] points</div>
+      <div class="line"><span class="keyword">ColorRGBA</span>[] colors</div>
+    </div></td>
+    <td class="markdownTableBodyLeft">标记显示，允许以编程方式向 LViz 3D 视图添加各种基本形状</td>
+  </tr>
+  <tr class="markdownTableRowEven">
+    <td class="markdownTableBodyLeft"><code>MarkerArray</code></td>
+    <td class="markdownTableBodyLeft"><div class="fragment">
+      <div class="line"><span class="keyword">Header</span> header</div>
+      <div class="line"><span class="keyword">viz/Marker</span>[] markers</div>
+    </div></td>
+    <td class="markdownTableBodyLeft">标记显示数组，允许一次发布多个标记以提高效率</td>
+  </table>
   </div>
 
 </div>

--- a/extra/tracker/test/gyro_tracker_test.cpp
+++ b/extra/tracker/test/gyro_tracker_test.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "rmvl/rmvl_modules.hpp"
+#include <cstdint>
 
 #ifdef HAVE_RMVL_GYRO_TRACKER
 
@@ -30,7 +31,7 @@ class GyroTrackerTest : public testing::Test {
     cv::Mat src;
 
 public:
-    double tick{Time::now()};
+    int64_t tick{Time::now()};
     ImuData imu_data{};
 
     void SetUp() override {

--- a/modules/lpss/include/rmvl/lpss/cv.hpp
+++ b/modules/lpss/include/rmvl/lpss/cv.hpp
@@ -131,11 +131,10 @@ cv::Mat from_msg(const msg::Image &img_msg);
  * @brief 从 cv::Mat 转换为 Image 消息
  *
  * @param[in] img OpenCV 图像矩阵
- * @param[in] encoding 图像编码格式，包括 "rgb8", "bgr8", "mono8", "mono16", "rgba8",
- * "bgra8", "bayer_rggb8" 和 "bayer_bggr8"
+ * @param[in] encoding 图像编码格式，必须是 msg::Image 中定义的编码类型之一
  * @return Image 图像消息
  */
-msg::Image to_msg(cv::Mat img, std::string_view encoding);
+msg::Image to_msg(cv::Mat img, uint8_t encoding);
 
 } // namespace cvmsg
 

--- a/modules/lpss/msg/sensor/Image.msg
+++ b/modules/lpss/msg/sensor/Image.msg
@@ -14,8 +14,21 @@ Header header # Header timestamp should be acquisition time of image
 int32 height # image height, that is, number of rows
 int32 width  # image width, that is, number of columns
 
-string encoding # Encoding of pixels -- channel meaning, ordering
-                # contain "rgb8", "bgr8", "mono8", "mono16", "rgba8",
-                # "bgra8", "bayer_rggb8", "bayer_bggr8",
-                # "bayer_rggb16", "bayer_bggbr16", "yuv422", "yuv420"
-uint8[] data    # actual matrix data
+uint8 encoding_rgb8 = 0
+uint8 encoding_bgr8 = 1
+uint8 encoding_mono8 = 2
+uint8 encoding_mono16 = 3
+uint8 encoding_rgba8 = 4
+uint8 encoding_bgra8 = 5
+uint8 encoding_bayer_rggb8 = 6
+uint8 encoding_bayer_bggr8 = 7
+uint8 encoding_bayer_rggb16 = 8
+uint8 encoding_bayer_bggbr16 = 9
+uint8 encoding_yuv422 = 10
+uint8 encoding_yuv420 = 11
+
+uint8 encoding # Encoding of pixels -- channel meaning, ordering
+               # contain "rgb8", "bgr8", "mono8", "mono16", "rgba8",
+               # "bgra8", "bayer_rggb8", "bayer_bggr8",
+               # "bayer_rggb16", "bayer_bggbr16", "yuv422", "yuv420"
+uint8[] data   # actual matrix data

--- a/modules/lpss/src/cv.cpp
+++ b/modules/lpss/src/cv.cpp
@@ -9,8 +9,6 @@
  *
  */
 
-#include <unordered_set>
-
 #include "rmvl/lpss/cv.hpp"
 
 #ifdef HAVE_OPENCV
@@ -55,37 +53,44 @@ cv::Mat from_msg(const msg::Image &img_msg) {
     if (img_msg.data.empty()) {
         return cv::Mat{};
     }
-    if (img_msg.encoding == "mono8")
+    if (img_msg.encoding == msg::Image::encoding_mono8)
         return cv::Mat(img_msg.height, img_msg.width, CV_8UC1, const_cast<uint8_t *>(img_msg.data.data())).clone();
-    else if (img_msg.encoding == "bgr8" || img_msg.encoding == "rgb8")
+    else if (img_msg.encoding == msg::Image::encoding_bgr8 || img_msg.encoding == msg::Image::encoding_rgb8)
         return cv::Mat(img_msg.height, img_msg.width, CV_8UC3, const_cast<uint8_t *>(img_msg.data.data())).clone();
-    else if (img_msg.encoding == "rgba8" || img_msg.encoding == "bgra8")
+    else if (img_msg.encoding == msg::Image::encoding_rgba8 || img_msg.encoding == msg::Image::encoding_bgra8)
         return cv::Mat(img_msg.height, img_msg.width, CV_8UC4, const_cast<uint8_t *>(img_msg.data.data())).clone();
-    else if (img_msg.encoding == "mono16")
+    else if (img_msg.encoding == msg::Image::encoding_mono16)
         return cv::Mat(img_msg.height, img_msg.width, CV_16UC1, const_cast<uint8_t *>(img_msg.data.data())).clone();
-    else if (img_msg.encoding == "bayer_rggb8")
+    else if (img_msg.encoding == msg::Image::encoding_bayer_rggb8)
         return cv::Mat(img_msg.height, img_msg.width, CV_8UC1, const_cast<uint8_t *>(img_msg.data.data())).clone();
-    else if (img_msg.encoding == "bayer_bggr8")
+    else if (img_msg.encoding == msg::Image::encoding_bayer_bggr8)
         return cv::Mat(img_msg.height, img_msg.width, CV_8UC1, const_cast<uint8_t *>(img_msg.data.data())).clone();
+    else if (img_msg.encoding == msg::Image::encoding_bayer_rggb16)
+        return cv::Mat(img_msg.height, img_msg.width, CV_16UC1, const_cast<uint8_t *>(img_msg.data.data())).clone();
+    else if (img_msg.encoding == msg::Image::encoding_bayer_bggbr16)
+        return cv::Mat(img_msg.height, img_msg.width, CV_16UC1, const_cast<uint8_t *>(img_msg.data.data())).clone();
+    else if (img_msg.encoding == msg::Image::encoding_yuv422)
+        return cv::Mat(img_msg.height, img_msg.width, CV_8UC2, const_cast<uint8_t *>(img_msg.data.data())).clone();
+    else if (img_msg.encoding == msg::Image::encoding_yuv420)
+        return cv::Mat(img_msg.height * 3 / 2, img_msg.width, CV_8UC1, const_cast<uint8_t *>(img_msg.data.data())).clone();
     else
         return cv::Mat{};
 }
 
-msg::Image to_msg(cv::Mat img, std::string_view encoding) {
-    static std::unordered_set<std::string> valid_encodings = {"rgb8", "bgr8", "mono8", "mono16", "rgba8", "bgra8", "bayer_rggb8", "bayer_bggr8"};
-    if (valid_encodings.find(std::string(encoding)) == valid_encodings.end())
+msg::Image to_msg(cv::Mat img, uint8_t encoding) {
+    if (encoding > msg::Image::encoding_yuv420 || img.empty())
         return msg::Image{};
-
-    if (!img.isContinuous())
-        img = img.clone();
 
     msg::Image img_msg{};
     img_msg.height = img.rows;
     img_msg.width = img.cols;
     img_msg.encoding = encoding;
-    size_t data_size = img.total() * img.elemSize();
-    img_msg.data.resize(data_size);
-    std::memcpy(img_msg.data.data(), img.data, data_size);
+
+    size_t row_bytes = img.cols * img.elemSize();
+    img_msg.data.resize(img.rows * row_bytes);
+    for (int i = 0; i < img.rows; ++i)
+        std::memcpy(img_msg.data.data() + i * row_bytes, img.ptr(i), row_bytes);
+
     return img_msg;
 }
 


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

简化 `rm::rmg::Image` 类型的 encoding