### PR TITLE
修改 DgramSocket 中 SocketWriteAwaiter 的地址存储方式

### DIFF
--- a/modules/io/include/rmvl/io/socket.hpp
+++ b/modules/io/include/rmvl/io/socket.hpp
@@ -701,7 +701,7 @@ public:
         //! @endcond
 
     private:
-        std::string_view _addr;
+        std::string _addr;
         Endpoint _endpoint;
     };
 

--- a/modules/io/src/ipc.cpp
+++ b/modules/io/src/ipc.cpp
@@ -191,7 +191,7 @@ PipeClient::~PipeClient() {
         ::close(_fd);
 }
 
-SHMBase::SHMBase(std::string_view name, std::size_t size) : _size(size), _name(name.find('/') == 0 ? std::string(name) : "/"s + std::string(name)) {
+SHMBase::SHMBase(std::string_view name, std::size_t size) : _size(size), _name(name.find('/') == 0 ? std::string(name) : "/"s.append(name)) {
     _fd = ::shm_open(_name.c_str(), O_RDWR | O_CREAT | O_EXCL, 0666);
 
     if (_fd >= 0)

--- a/modules/io/src/socket.cpp
+++ b/modules/io/src/socket.cpp
@@ -428,7 +428,7 @@ struct _dgram_sendto_res {
     socklen_t addr_len{};
 };
 
-static _dgram_sendto_res parse_sendto(const std::string_view &addr, const Endpoint &endpoint) noexcept {
+static _dgram_sendto_res parse_sendto(std::string_view addr, const Endpoint &endpoint) noexcept {
     _dgram_sendto_res res{};
     if (endpoint.family() == AF_INET) {
         auto *dst_addr = reinterpret_cast<sockaddr_in *>(&res.dst_storage);


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 为兼容 `std::array<uint8_t, 4>` 的地址表示法，地址字符串改为使用 `std::string`
- 修改 `SHMBase` 的右值字符串相加
- 修改 `parse_sendto` 的入参