### PR TITLE
调整 math.hpp 中头文件包含顺序，以保证 `cv::Matx` 的正常使用

### DIFF
--- a/modules/algorithm/include/rmvl/algorithm/math.hpp
+++ b/modules/algorithm/include/rmvl/algorithm/math.hpp
@@ -16,14 +16,14 @@
 #include <unordered_map>
 #include <vector>
 
+#include "rmvl/core/util.hpp"
+
 #ifdef HAVE_OPENCV
 #include <opencv2/core/matx.hpp>
 #else
 #include <algorithm>
 #include <memory>
 #endif // HAVE_OPENCV
-
-#include "rmvl/core/util.hpp"
 
 namespace rm {
 


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

修复由于 `HAVE_OPENCV` 定义在相关头文件包含之前导致 `cv::Matx` 无法正常使用的问题