### PR TITLE
修复 io 模块资源类所有权和异步 I/O 问题

### DIFF
--- a/modules/io/include/rmvl/io/async.hpp
+++ b/modules/io/include/rmvl/io/async.hpp
@@ -104,7 +104,9 @@ class Promise<void> : public BasicPromise {
 public:
     auto get_return_object() noexcept { return std::coroutine_handle<Promise>::from_promise(*this); }
     FinalAwaiter<void> final_suspend() noexcept { return {}; }
-    void return_void() {
+    void return_void() noexcept {}
+
+    void get() {
         if (_exception)
             std::rethrow_exception(_exception);
     }
@@ -131,11 +133,11 @@ struct TaskAwaiter {
         self.promise().previous = handle;
         return self;
     }
-    Tp await_resume() noexcept {
+    Tp await_resume() {
         if constexpr (!std::is_void_v<Tp>)
             return self.promise().get();
         else
-            return;
+            self.promise().get();
     }
 
     handle_t self{};
@@ -154,13 +156,21 @@ public:
     Task &operator=(const Task &) = delete;
 
     Task(Task &&other) noexcept : _handle(other._handle) { other._handle = nullptr; }
-    Task &operator=(Task &&other) noexcept = default;
+    Task &operator=(Task &&other) noexcept {
+        if (this != &other) {
+            _handle ? _handle.destroy() : void(0);
+            _handle = other._handle;
+            other._handle = nullptr;
+        }
+        return *this;
+    }
 
     TaskAwaiter<Tp> operator co_await() noexcept { return TaskAwaiter<Tp>{_handle}; }
 
     ~Task() { _handle ? _handle.destroy() : void(0); }
 
     std::coroutine_handle<> handle() const noexcept { return _handle; }
+    promise_type &promise() const noexcept { return _handle.promise(); }
 
 private:
     handle_t _handle{};
@@ -170,7 +180,7 @@ private:
 template <typename Callable, typename... Args>
 concept InvokableTask = requires(Callable &&c, Args &&...args) {
     typename std::invoke_result_t<Callable, Args...>::promise_type;
-    { std::invoke(std::forward<Callable>(c), std::forward<Args>(args)...) };
+    {std::invoke(std::forward<Callable>(c), std::forward<Args>(args)...)};
 };
 
 //! 异步 I/O 执行上下文，负责管理 IO 事件循环和协程任务的调度
@@ -201,7 +211,7 @@ public:
      * - 带捕获列表的 lambda 也可以作为 `fn`，但极易引起悬垂引用的未定义行为
      */
     template <typename Callable, typename... Args>
-        requires InvokableTask<Callable, Args...>
+    requires InvokableTask<Callable, Args...>
     void spawn(Callable &&fn, Args &&...args) {
         using Tp = typename std::invoke_result_t<Callable, Args...>::value_type;
         _ready.emplace(std::make_unique<TaskWrapper<Tp>>(std::invoke(std::forward<Callable>(fn), std::forward<Args>(args)...)));
@@ -225,6 +235,7 @@ private:
 
         virtual ~BasicTask() = default;
         virtual std::coroutine_handle<> handle() const noexcept = 0;
+        virtual void rethrow_if_exception() = 0;
     };
 
     template <typename Tp>
@@ -233,6 +244,12 @@ private:
 
         explicit TaskWrapper(Task<Tp> &&t) : task(std::move(t)) {}
         std::coroutine_handle<> handle() const noexcept override { return task.handle(); }
+        void rethrow_if_exception() override {
+            if constexpr (std::is_void_v<Tp>)
+                task.promise().get();
+            else
+                static_cast<void>(task.promise().get());
+        }
 
         Task<Tp> task{};
     };
@@ -261,7 +278,7 @@ using IOContextRef = std::reference_wrapper<IOContext>;
  * - 异步 I/O 执行上下文 IOContext::spawn
  */
 template <typename Callable, typename... Args>
-    requires InvokableTask<Callable, Args...>
+requires InvokableTask<Callable, Args...>
 inline void co_spawn(IOContext &ctx, Callable &&fn, Args &&...args) {
     ctx.spawn(std::forward<Callable>(fn), std::forward<Args>(args)...);
 }
@@ -272,7 +289,7 @@ inline void co_spawn(IOContext &ctx, Callable &&fn, Args &&...args) {
 struct IocpOverlapped {
     OVERLAPPED ov{};
     std::coroutine_handle<> handle{};
-    char info[256]{}; //! 附加信息存储区
+    char info[256]{};  //! 附加信息存储区
     char buf[65536]{}; //! 实际发生传输的数据
 
     IocpOverlapped(std::coroutine_handle<> h) : handle(h) {}

--- a/modules/io/include/rmvl/io/ipc.hpp
+++ b/modules/io/include/rmvl/io/ipc.hpp
@@ -26,9 +26,9 @@ namespace rm {
 class RMVL_EXPORTS_W PipeServer {
 public:
     PipeServer(const PipeServer &) = delete;
-    PipeServer(PipeServer &&) = default;
+    PipeServer(PipeServer &&other) noexcept;
     PipeServer &operator=(const PipeServer &) = delete;
-    PipeServer &operator=(PipeServer &&) = default;
+    PipeServer &operator=(PipeServer &&other) noexcept;
     ~PipeServer();
 
     /**
@@ -74,16 +74,16 @@ protected:
     PipeServer(std::string_view name, bool ov);
 
     std::string _name;    //!< 命名管道名称
-    FileDescriptor _fd{}; //!< 文件句柄
+    FileDescriptor _fd{INVALID_FD}; //!< 文件句柄
 };
 
 //! 命名管道客户端
 class RMVL_EXPORTS_W PipeClient {
 public:
     PipeClient(const PipeClient &) = delete;
-    PipeClient(PipeClient &&) = default;
+    PipeClient(PipeClient &&other) noexcept;
     PipeClient &operator=(const PipeClient &) = delete;
-    PipeClient &operator=(PipeClient &&) = default;
+    PipeClient &operator=(PipeClient &&other) noexcept;
     ~PipeClient();
 
     /**
@@ -125,7 +125,7 @@ public:
 protected:
     PipeClient(std::string_view name, bool ov);
 
-    FileDescriptor _fd{}; //!< 文件句柄
+    FileDescriptor _fd{INVALID_FD}; //!< 文件句柄
 };
 
 //! 消息队列服务端
@@ -139,9 +139,9 @@ public:
     RMVL_W MqServer(std::string_view name);
 
     MqServer(const MqServer &) = delete;
-    MqServer(MqServer &&) = default;
+    MqServer(MqServer &&other) noexcept;
     MqServer &operator=(const MqServer &) = delete;
-    MqServer &operator=(MqServer &&) = default;
+    MqServer &operator=(MqServer &&other) noexcept;
     ~MqServer();
 
     /**
@@ -176,7 +176,7 @@ public:
 
 protected:
     std::string _name{};  //!< 消息队列名称
-    FileDescriptor _mq{}; //!< 消息队列描述符句柄
+    FileDescriptor _mq{INVALID_FD}; //!< 消息队列描述符句柄
 };
 
 //! 消息队列客户端
@@ -190,9 +190,9 @@ public:
     RMVL_W MqClient(std::string_view name);
 
     MqClient(const MqClient &) = delete;
-    MqClient(MqClient &&) = default;
+    MqClient(MqClient &&other) noexcept;
     MqClient &operator=(const MqClient &) = delete;
-    MqClient &operator=(MqClient &&) = default;
+    MqClient &operator=(MqClient &&other) noexcept;
     ~MqClient();
 
     /**
@@ -227,9 +227,9 @@ public:
 
 protected:
 #ifdef _WIN32
-    HANDLE _mq{}; //!< 消息队列句柄
+    HANDLE _mq{INVALID_HANDLE_VALUE}; //!< 消息队列句柄
 #else
-    int _mq{}; //!< 消息队列描述符
+    int _mq{INVALID_FD}; //!< 消息队列描述符
 #endif
 };
 
@@ -246,9 +246,9 @@ public:
     ~SHMBase();
 
     SHMBase(const SHMBase &) = delete;
-    SHMBase(SHMBase &&) = default;
+    SHMBase(SHMBase &&other) noexcept;
     SHMBase &operator=(const SHMBase &) = delete;
-    SHMBase &operator=(SHMBase &&) = default;
+    SHMBase &operator=(SHMBase &&other) noexcept;
 
     /**
      * @brief 获取共享内存映射指针
@@ -271,7 +271,11 @@ private:
     std::size_t _size{};     //!< 共享内存大小
     std::string _name{};     //!< 共享内存名称
     void *_ptr{nullptr};     //!< 共享内存映射指针
-    FileDescriptor _fd{};    //!< 共享内存文件描述符
+#ifdef _WIN32
+    FileDescriptor _fd{nullptr};    //!< 共享内存文件描述符
+#else
+    FileDescriptor _fd{INVALID_FD}; //!< 共享内存文件描述符
+#endif
     bool _is_creator{false}; //!< 是否为创建者
 };
 

--- a/modules/io/include/rmvl/io/serial.hpp
+++ b/modules/io/include/rmvl/io/serial.hpp
@@ -60,9 +60,9 @@ public:
 
     //! @cond
     SerialPort(const SerialPort &) = delete;
-    SerialPort(SerialPort &&) = default;
+    SerialPort(SerialPort &&other) noexcept;
     SerialPort &operator=(const SerialPort &) = delete;
-    SerialPort &operator=(SerialPort &&) = default;
+    SerialPort &operator=(SerialPort &&other) noexcept;
     ~SerialPort();
     //! @endcond
 

--- a/modules/io/include/rmvl/io/socket.hpp
+++ b/modules/io/include/rmvl/io/socket.hpp
@@ -1266,18 +1266,21 @@ public:
     //! 连接等待器
     class ConnectAwaiter : public AsyncWriteAwaiter {
     public:
-        ConnectAwaiter(IOContext &ctx, SocketFd fd, const Endpoint &ep, std::string_view url)
-            : AsyncWriteAwaiter(ctx, FileDescriptor(fd), url), _ctx(ctx), _endpoint(ep) {}
+        ConnectAwaiter(IOContext &ctx, SocketFd &fd, const Endpoint &ep, std::string_view url)
+            : AsyncWriteAwaiter(ctx, FileDescriptor(fd), url), _ctx(ctx), _owner_fd(fd), _endpoint(ep) {}
 
         //! @cond
 #ifdef _WIN32
         void await_suspend(std::coroutine_handle<> handle);
+#else
+        bool await_suspend(std::coroutine_handle<> handle);
 #endif
         StreamSocket await_resume() noexcept;
         //! @endcond
 
     private:
         IOContextRef _ctx;  //!< 异步 I/O 执行上下文
+        SocketFd &_owner_fd; //!< 连接器持有的 Socket 描述符
         Endpoint _endpoint; //!< 端点
     };
 

--- a/modules/io/src/async.cpp
+++ b/modules/io/src/async.cpp
@@ -50,6 +50,15 @@ void IOContext::run() {
             task->handle().resume();
             if (!task->handle().done())
                 unfinish.insert({task->handle().address(), std::move(task)});
+            else {
+                try {
+                    task->rethrow_if_exception();
+                } catch (const std::exception &e) {
+                    WARNING_("Unhandled async task exception: %s", e.what());
+                } catch (...) {
+                    WARNING_("Unhandled async task exception");
+                }
+            }
         }
         // 处理 IO 事件
         constexpr std::size_t MAX_EVENTS = 256;
@@ -285,6 +294,15 @@ void IOContext::run() {
             task->handle().resume();
             if (!task->handle().done())
                 unfinish.insert({task->handle().address(), std::move(task)});
+            else {
+                try {
+                    task->rethrow_if_exception();
+                } catch (const std::exception &e) {
+                    WARNING_("Unhandled async task exception: %s", e.what());
+                } catch (...) {
+                    WARNING_("Unhandled async task exception");
+                }
+            }
         }
         // 处理 IO 事件
         constexpr std::size_t MAX_EVENTS = 256;
@@ -353,11 +371,7 @@ void AsyncWriteAwaiter::await_suspend(std::coroutine_handle<> handle) {
 bool AsyncWriteAwaiter::await_resume() {
     RMVL_DbgAssert(_fd >= 0);
     epoll_ctl(_aioh, EPOLL_CTL_DEL, _fd, nullptr);
-#if _WIN32
-    ssize_t n = ::write(_fd, _data.data(), static_cast<int>(_data.size()));
-#else
     ssize_t n = ::write(_fd, _data.data(), _data.size());
-#endif
     return n == static_cast<ssize_t>(_data.size());
 }
 

--- a/modules/io/src/ipc.cpp
+++ b/modules/io/src/ipc.cpp
@@ -24,6 +24,7 @@
 #endif
 
 #include <cstring>
+#include <utility>
 
 #include "rmvl/core/util.hpp"
 #include "rmvl/io/ipc.hpp"
@@ -109,14 +110,45 @@ PipeClient::PipeClient(std::string_view name, bool ov) {
 }
 
 PipeServer::~PipeServer() {
+    if (_fd == INVALID_HANDLE_VALUE)
+        return;
     if (!DisconnectNamedPipe(_fd))
         ERROR_("Failed to disconnect named pipe");
     closePipe(_fd);
+    _fd = INVALID_HANDLE_VALUE;
 }
 
 PipeClient::~PipeClient() {
-    if (_fd != INVALID_HANDLE_VALUE)
+    if (_fd != INVALID_HANDLE_VALUE) {
         closePipe(_fd);
+        _fd = INVALID_HANDLE_VALUE;
+    }
+}
+
+PipeServer::PipeServer(PipeServer &&other) noexcept
+    : _name(std::exchange(other._name, {})), _fd(std::exchange(other._fd, INVALID_HANDLE_VALUE)) {}
+
+PipeServer &PipeServer::operator=(PipeServer &&other) noexcept {
+    if (this != &other) {
+        if (_fd != INVALID_HANDLE_VALUE) {
+            DisconnectNamedPipe(_fd);
+            closePipe(_fd);
+        }
+        _name = std::exchange(other._name, {});
+        _fd = std::exchange(other._fd, INVALID_HANDLE_VALUE);
+    }
+    return *this;
+}
+
+PipeClient::PipeClient(PipeClient &&other) noexcept : _fd(std::exchange(other._fd, INVALID_HANDLE_VALUE)) {}
+
+PipeClient &PipeClient::operator=(PipeClient &&other) noexcept {
+    if (this != &other) {
+        if (_fd != INVALID_HANDLE_VALUE)
+            closePipe(_fd);
+        _fd = std::exchange(other._fd, INVALID_HANDLE_VALUE);
+    }
+    return *this;
 }
 
 SHMBase::SHMBase(std::string_view name, std::size_t size) : _size(size) {
@@ -146,6 +178,31 @@ SHMBase::~SHMBase() {
         UnmapViewOfFile(_ptr);
     if (_fd != nullptr)
         CloseHandle(_fd);
+    _ptr = nullptr;
+    _fd = nullptr;
+    _is_creator = false;
+}
+
+SHMBase::SHMBase(SHMBase &&other) noexcept
+    : _size(std::exchange(other._size, 0)),
+      _name(std::exchange(other._name, {})),
+      _ptr(std::exchange(other._ptr, nullptr)),
+      _fd(std::exchange(other._fd, nullptr)),
+      _is_creator(std::exchange(other._is_creator, false)) {}
+
+SHMBase &SHMBase::operator=(SHMBase &&other) noexcept {
+    if (this != &other) {
+        if (_ptr != nullptr)
+            UnmapViewOfFile(_ptr);
+        if (_fd != nullptr)
+            CloseHandle(_fd);
+        _size = std::exchange(other._size, 0);
+        _name = std::exchange(other._name, {});
+        _ptr = std::exchange(other._ptr, nullptr);
+        _fd = std::exchange(other._fd, nullptr);
+        _is_creator = std::exchange(other._is_creator, false);
+    }
+    return *this;
 }
 
 #else
@@ -181,14 +238,46 @@ PipeServer::PipeServer(std::string_view name, bool) : _name("/tmp/"s + name.data
 }
 
 PipeServer::~PipeServer() {
-    if (_fd != -1)
+    if (_fd != -1) {
         ::close(_fd);
+        _fd = -1;
+    }
+    if (!_name.empty())
+        ::unlink(_name.c_str());
 }
 
 PipeClient::PipeClient(std::string_view name, bool) : _fd(::open(("/tmp/"s + name.data()).c_str(), O_RDWR)) {}
 PipeClient::~PipeClient() {
-    if (_fd != -1)
+    if (_fd != -1) {
         ::close(_fd);
+        _fd = -1;
+    }
+}
+
+PipeServer::PipeServer(PipeServer &&other) noexcept
+    : _name(std::exchange(other._name, {})), _fd(std::exchange(other._fd, INVALID_FD)) {}
+
+PipeServer &PipeServer::operator=(PipeServer &&other) noexcept {
+    if (this != &other) {
+        if (_fd != -1)
+            ::close(_fd);
+        if (!_name.empty())
+            ::unlink(_name.c_str());
+        _name = std::exchange(other._name, {});
+        _fd = std::exchange(other._fd, INVALID_FD);
+    }
+    return *this;
+}
+
+PipeClient::PipeClient(PipeClient &&other) noexcept : _fd(std::exchange(other._fd, INVALID_FD)) {}
+
+PipeClient &PipeClient::operator=(PipeClient &&other) noexcept {
+    if (this != &other) {
+        if (_fd != -1)
+            ::close(_fd);
+        _fd = std::exchange(other._fd, INVALID_FD);
+    }
+    return *this;
 }
 
 SHMBase::SHMBase(std::string_view name, std::size_t size) : _size(size), _name(name.find('/') == 0 ? std::string(name) : "/"s.append(name)) {
@@ -243,12 +332,39 @@ SHMBase::SHMBase(std::string_view name, std::size_t size) : _size(size), _name(n
 }
 
 SHMBase::~SHMBase() {
-    if (_ptr != MAP_FAILED)
+    if (_ptr != nullptr && _ptr != MAP_FAILED)
         munmap(_ptr, _size);
     if (_fd != -1)
         close(_fd);
     if (_is_creator)
         ::shm_unlink(_name.c_str());
+    _ptr = nullptr;
+    _fd = -1;
+    _is_creator = false;
+}
+
+SHMBase::SHMBase(SHMBase &&other) noexcept
+    : _size(std::exchange(other._size, 0)),
+      _name(std::exchange(other._name, {})),
+      _ptr(std::exchange(other._ptr, nullptr)),
+      _fd(std::exchange(other._fd, INVALID_FD)),
+      _is_creator(std::exchange(other._is_creator, false)) {}
+
+SHMBase &SHMBase::operator=(SHMBase &&other) noexcept {
+    if (this != &other) {
+        if (_ptr != nullptr && _ptr != MAP_FAILED)
+            munmap(_ptr, _size);
+        if (_fd != -1)
+            close(_fd);
+        if (_is_creator)
+            ::shm_unlink(_name.c_str());
+        _size = std::exchange(other._size, 0);
+        _name = std::exchange(other._name, {});
+        _ptr = std::exchange(other._ptr, nullptr);
+        _fd = std::exchange(other._fd, INVALID_FD);
+        _is_creator = std::exchange(other._is_creator, false);
+    }
+    return *this;
 }
 
 #endif
@@ -308,6 +424,21 @@ bool MqClient::write(std::string_view, uint32_t) noexcept { return false; }
 MqServer::~MqServer() {}
 MqClient::~MqClient() {}
 
+MqServer::MqServer(MqServer &&other) noexcept : _name(std::exchange(other._name, {})), _mq(std::exchange(other._mq, INVALID_HANDLE_VALUE)) {}
+MqServer &MqServer::operator=(MqServer &&other) noexcept {
+    if (this != &other) {
+        _name = std::exchange(other._name, {});
+        _mq = std::exchange(other._mq, INVALID_HANDLE_VALUE);
+    }
+    return *this;
+}
+MqClient::MqClient(MqClient &&other) noexcept : _mq(std::exchange(other._mq, INVALID_HANDLE_VALUE)) {}
+MqClient &MqClient::operator=(MqClient &&other) noexcept {
+    if (this != &other)
+        _mq = std::exchange(other._mq, INVALID_HANDLE_VALUE);
+    return *this;
+}
+
 #else
 
 MqServer::MqServer(std::string_view name) : _name(name) {
@@ -324,9 +455,26 @@ MqServer::MqServer(std::string_view name) : _name(name) {
 }
 
 MqServer::~MqServer() {
-    if (_mq >= 0)
+    if (_mq >= 0) {
         mq_close(_mq);
-    mq_unlink(_name.data());
+        _mq = -1;
+    }
+    if (!_name.empty())
+        mq_unlink(_name.data());
+}
+
+MqServer::MqServer(MqServer &&other) noexcept : _name(std::exchange(other._name, {})), _mq(std::exchange(other._mq, INVALID_FD)) {}
+
+MqServer &MqServer::operator=(MqServer &&other) noexcept {
+    if (this != &other) {
+        if (_mq >= 0)
+            mq_close(_mq);
+        if (!_name.empty())
+            mq_unlink(_name.data());
+        _name = std::exchange(other._name, {});
+        _mq = std::exchange(other._mq, INVALID_FD);
+    }
+    return *this;
 }
 
 MqClient::MqClient(std::string_view name) : _mq(mq_open(name.data(), O_RDWR)) {
@@ -337,8 +485,21 @@ MqClient::MqClient(std::string_view name) : _mq(mq_open(name.data(), O_RDWR)) {
 }
 
 MqClient::~MqClient() {
-    if (_mq >= 0)
+    if (_mq >= 0) {
         mq_close(_mq);
+        _mq = -1;
+    }
+}
+
+MqClient::MqClient(MqClient &&other) noexcept : _mq(std::exchange(other._mq, INVALID_FD)) {}
+
+MqClient &MqClient::operator=(MqClient &&other) noexcept {
+    if (this != &other) {
+        if (_mq >= 0)
+            mq_close(_mq);
+        _mq = std::exchange(other._mq, INVALID_FD);
+    }
+    return *this;
 }
 
 static std::string mqRead(int mq) noexcept {

--- a/modules/io/src/netapp.cpp
+++ b/modules/io/src/netapp.cpp
@@ -402,18 +402,28 @@ URLParseInfo parseURL(std::string_view url) {
 
     // 查找路径部分
     auto path_start = url.find('/');
+    auto query_start = url.find('?');
+    if (query_start != std::string_view::npos && path_start != std::string_view::npos && query_start < path_start)
+        path_start = std::string_view::npos;
     std::string_view host_part;
     if (path_start != std::string_view::npos) {
         host_part = url.substr(0, path_start);
         path = url.substr(path_start);
     } else {
-        host_part = url;
+        host_part = query_start == std::string_view::npos ? url : url.substr(0, query_start);
         path = "/";
     }
 
     // 查找端口部分
-    auto port_start = host_part.find(':');
-    if (port_start != std::string_view::npos) {
+    auto port_start = host_part.rfind(':');
+    if (!host_part.empty() && host_part.front() == '[') {
+        auto ipv6_end = host_part.find(']');
+        hostname = ipv6_end == std::string_view::npos ? host_part : host_part.substr(1, ipv6_end - 1);
+        if (ipv6_end != std::string_view::npos && ipv6_end + 1 < host_part.size() && host_part[ipv6_end + 1] == ':') {
+            auto port_str = host_part.substr(ipv6_end + 2);
+            port = static_cast<uint16_t>(std::stoi(std::string(port_str)));
+        }
+    } else if (port_start != std::string_view::npos) {
         hostname = host_part.substr(0, port_start);
         auto port_str = host_part.substr(port_start + 1);
         port = static_cast<uint16_t>(std::stoi(std::string(port_str)));
@@ -421,9 +431,8 @@ URLParseInfo parseURL(std::string_view url) {
         hostname = host_part;
 
     // 查找查询参数部分
-    auto query_start = url.find('?');
     if (query_start != std::string_view::npos) {
-        path = url.substr(path_start, query_start - path_start);
+        path = path_start == std::string_view::npos ? "/" : std::string(url.substr(path_start, query_start - path_start));
         auto query_str = url.substr(query_start + 1);
         query = str::split(query_str, "&");
     }

--- a/modules/io/src/serial.cpp
+++ b/modules/io/src/serial.cpp
@@ -16,6 +16,8 @@
 #include <unistd.h>
 #endif
 
+#include <utility>
+
 #if __cplusplus >= 202002L
 
 #ifndef _WIN32
@@ -30,9 +32,28 @@
 
 namespace rm {
 
-SerialPort::~SerialPort() = default;
+SerialPort::~SerialPort() { close(); }
 
 SerialPort::SerialPort(std::string_view device, BaudRate rate, SerialReadMode mode) : _device(device), _baud_rate(rate), _read_mode(mode) { open(); }
+
+SerialPort::SerialPort(SerialPort &&other) noexcept
+    : _fd(std::exchange(other._fd, INVALID_FD)),
+      _is_open(std::exchange(other._is_open, false)),
+      _device(std::move(other._device)),
+      _baud_rate(other._baud_rate),
+      _read_mode(other._read_mode) {}
+
+SerialPort &SerialPort::operator=(SerialPort &&other) noexcept {
+    if (this != &other) {
+        close();
+        _fd = std::exchange(other._fd, INVALID_FD);
+        _is_open = std::exchange(other._is_open, false);
+        _device = std::move(other._device);
+        _baud_rate = other._baud_rate;
+        _read_mode = other._read_mode;
+    }
+    return *this;
+}
 
 static unsigned int getBaudRate(BaudRate baud_rate) {
 #ifdef _WIN32
@@ -59,6 +80,7 @@ bool SerialPort::read(std::string &data) {
 
 void SerialPort::open() {
     INFO_("Opening the serial port: %s", _device.c_str());
+    close();
     _fd = CreateFileA(
         _device.c_str(),
         GENERIC_READ | GENERIC_WRITE,
@@ -108,8 +130,9 @@ void SerialPort::open() {
 }
 
 void SerialPort::close() {
-    if (_is_open)
+    if (_is_open && _fd != INVALID_HANDLE_VALUE)
         CloseHandle(_fd);
+    _fd = INVALID_HANDLE_VALUE;
     _is_open = false;
 }
 
@@ -147,6 +170,7 @@ long int SerialPort::fdread(void *data, std::size_t len) {
 
 void SerialPort::open() {
     INFO_("Opening the serial port: %s", _device.c_str());
+    close();
     _fd = ::open(_device.c_str(), O_RDWR | O_NOCTTY | O_NDELAY);
     if (_fd < 0) {
         ERROR_("Failed to open the serial port.");
@@ -183,8 +207,9 @@ void SerialPort::open() {
 }
 
 void SerialPort::close() {
-    if (_is_open)
+    if (_is_open && _fd >= 0)
         ::close(_fd);
+    _fd = INVALID_FD;
     _is_open = false;
 }
 
@@ -240,13 +265,23 @@ SerialPort::SerialPort(IOContext &io_context, std::string_view device, BaudRate 
 }
 
 std::string SerialPort::SerialReadAwaiter::await_resume() noexcept {
+    DWORD bytes_transferred{};
+    if (!_ovl || !GetOverlappedResult(_fd, &_ovl->ov, &bytes_transferred, false)) {
+        WARNING_("Serial read failed, error code: %lu", GetLastError());
+        return {};
+    }
     PurgeComm(_fd, PURGE_RXCLEAR);
-    return _ovl ? _ovl->buf : std::string{};
+    return std::string(_ovl->buf, bytes_transferred);
 }
 
 bool SerialPort::SerialWriteAwaiter::await_resume() noexcept {
+    DWORD bytes_transferred{};
+    if (!_ovl || !GetOverlappedResult(_fd, &_ovl->ov, &bytes_transferred, false)) {
+        WARNING_("Serial write failed, error code: %lu", GetLastError());
+        return false;
+    }
     PurgeComm(_fd, PURGE_TXCLEAR);
-    return _ovl != nullptr;
+    return bytes_transferred == _data.size();
 }
 
 #else

--- a/modules/io/src/socket.cpp
+++ b/modules/io/src/socket.cpp
@@ -451,6 +451,14 @@ static _dgram_sendto_res parse_sendto(std::string_view addr, const Endpoint &end
 
 static constexpr size_t MAX_IOVEC = 64;
 
+static size_t expected_iovec_bytes(const std::vector<std::string_view> &buffers) noexcept {
+    size_t expected = 0;
+    const size_t count = std::min(buffers.size(), MAX_IOVEC);
+    for (size_t i = 0; i < count; ++i)
+        expected += buffers[i].size();
+    return expected;
+}
+
 #ifdef _WIN32
 
 static size_t build_write_wsabuf(const std::vector<std::string_view> &buffers, WSABUF *wsabufs) noexcept {
@@ -563,9 +571,7 @@ bool DgramSocket::multiwrite(std::string_view addr, const Endpoint &endpoint, co
     if (_fd == INVALID_SOCKET_FD || buffers.empty())
         return false;
     auto [dst_storage, addr_len] = parse_sendto(addr, endpoint);
-    size_t expected = 0;
-    for (const auto &buf : buffers)
-        expected += buf.size();
+    size_t expected = expected_iovec_bytes(buffers);
 
 #ifdef _WIN32
     WSABUF wsabufs[MAX_IOVEC];
@@ -686,9 +692,7 @@ bool StreamSocket::write(std::string_view data) noexcept {
 bool StreamSocket::multiwrite(const std::vector<std::string_view> &buffers) noexcept {
     if (_fd == INVALID_SOCKET_FD || buffers.empty())
         return false;
-    size_t expected = 0;
-    for (const auto &buf : buffers)
-        expected += buf.size();
+    size_t expected = expected_iovec_bytes(buffers);
 
 #ifdef _WIN32
     WSABUF wsabufs[MAX_IOVEC];
@@ -823,11 +827,6 @@ DgramSocket Sender::create() {
     return DgramSocket(fd);
 }
 
-StreamSocket &StreamSocket::operator=(StreamSocket &&other) noexcept {
-    _fd = std::exchange(other._fd, INVALID_SOCKET_FD);
-    return *this;
-}
-
 #ifdef _WIN32
 Acceptor::Acceptor(const Endpoint &ep, bool blocking, bool ov) : _endpoint(ep) {
     SocketEnv::ensure_init();
@@ -885,6 +884,7 @@ Connector::Connector(const Endpoint &ep, std::string_view url, bool blocking, bo
 
 StreamSocket Connector::connect() {
     int sfd = fdconnect(static_cast<int>(_fd), _endpoint, _url);
+    _fd = INVALID_SOCKET_FD;
     return StreamSocket(sfd);
 }
 
@@ -900,6 +900,33 @@ static bool valid(SocketFd fd) {
         return false;
     return fcntl(fd, F_GETFD) != -1;
 #endif
+}
+
+static void close_socket(SocketFd &fd) noexcept {
+    if (!valid(fd))
+        return;
+#ifdef _WIN32
+    ::closesocket(fd);
+#else
+    ::close(fd);
+#endif
+    fd = INVALID_SOCKET_FD;
+}
+
+static bool fill_sockaddr(const Endpoint &ep, std::string_view url, sockaddr_storage &storage, socklen_t &addr_len) {
+    if (ep.family() == AF_INET) {
+        auto *addr = reinterpret_cast<sockaddr_in *>(&storage);
+        addr->sin_family = AF_INET;
+        addr->sin_port = htons(ep.port());
+        return inet_pton(AF_INET, url.data(), &addr->sin_addr) == 1 ? (addr_len = sizeof(sockaddr_in), true) : false;
+    }
+    if (ep.family() == AF_INET6) {
+        auto *addr = reinterpret_cast<sockaddr_in6 *>(&storage);
+        addr->sin6_family = AF_INET6;
+        addr->sin6_port = htons(ep.port());
+        return inet_pton(AF_INET6, url.data(), &addr->sin6_addr) == 1 ? (addr_len = sizeof(sockaddr_in6), true) : false;
+    }
+    return false;
 }
 
 #ifdef _WIN32
@@ -929,6 +956,22 @@ Acceptor::~Acceptor() { valid(_fd) ? ::close(_fd) : 0; }
 Connector::~Connector() { valid(_fd) ? ::close(_fd) : 0; }
 
 #endif
+
+DgramSocket &DgramSocket::operator=(DgramSocket &&other) noexcept {
+    if (this != &other) {
+        close_socket(_fd);
+        _fd = std::exchange(other._fd, INVALID_SOCKET_FD);
+    }
+    return *this;
+}
+
+StreamSocket &StreamSocket::operator=(StreamSocket &&other) noexcept {
+    if (this != &other) {
+        close_socket(_fd);
+        _fd = std::exchange(other._fd, INVALID_SOCKET_FD);
+    }
+    return *this;
+}
 
 #ifdef __MSVC__
 #pragma endregion
@@ -1102,9 +1145,7 @@ bool DgramSocket::SocketMultiWriteAwaiter::await_resume() {
     if (!GetOverlappedResult((HANDLE)_fd, &_ovl->ov, &bytes_transferred, FALSE)) {
         return false;
     }
-    size_t expected = 0;
-    for (const auto &buf : _buffers)
-        expected += buf.size();
+    size_t expected = expected_iovec_bytes(_buffers);
     return static_cast<size_t>(bytes_transferred) == expected;
 }
 
@@ -1164,9 +1205,7 @@ bool StreamSocket::SocketMultiWriteAwaiter::await_resume() {
     if (!GetOverlappedResult((HANDLE)_fd, &_ovl->ov, &bytes_transferred, FALSE)) {
         return false;
     }
-    size_t expected = 0;
-    for (const auto &buf : _buffers)
-        expected += buf.size();
+    size_t expected = expected_iovec_bytes(_buffers);
     return static_cast<size_t>(bytes_transferred) == expected;
 }
 
@@ -1336,6 +1375,7 @@ void Connector::ConnectAwaiter::await_suspend(std::coroutine_handle<> handle) {
 StreamSocket Connector::ConnectAwaiter::await_resume() noexcept {
     RMVL_DbgAssert(_fd != INVALID_FD);
     SOCKET sfd = (SOCKET)_fd;
+    _owner_fd = INVALID_SOCKET_FD;
     // 更新 socket 上下文
     if (setsockopt(sfd, SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT, NULL, 0) == SOCKET_ERROR)
         WARNING_("setsockopt SO_UPDATE_CONNECT_CONTEXT failed: %d", WSAGetLastError());
@@ -1408,9 +1448,7 @@ bool DgramSocket::SocketMultiWriteAwaiter::await_resume() {
     msg.msg_iovlen = iov_cnt;
 
     ssize_t n = ::sendmsg(_fd, &msg, 0);
-    size_t expected = 0;
-    for (const auto &buf : _buffers)
-        expected += buf.size();
+    size_t expected = expected_iovec_bytes(_buffers);
     return n >= 0 && static_cast<size_t>(n) == expected;
 }
 
@@ -1456,15 +1494,13 @@ bool StreamSocket::SocketMultiWriteAwaiter::await_resume() {
     msg.msg_iovlen = iov_cnt;
 
     ssize_t n = ::sendmsg(_fd, &msg, 0);
-    size_t expected = 0;
-    for (const auto &buf : _buffers)
-        expected += buf.size();
+    size_t expected = expected_iovec_bytes(_buffers);
     return n >= 0 && static_cast<size_t>(n) == expected;
 }
 
-Sender::Sender(IOContext &io_context, const ip::Protocol &protocol) : ::rm::Sender(protocol, true), _ctx(io_context) {}
+Sender::Sender(IOContext &io_context, const ip::Protocol &protocol) : ::rm::Sender(protocol, false), _ctx(io_context) {}
 
-Listener::Listener(IOContext &io_context, const Endpoint &endpoint) : ::rm::Listener(endpoint, true), _ctx(io_context) {}
+Listener::Listener(IOContext &io_context, const Endpoint &endpoint) : ::rm::Listener(endpoint, false), _ctx(io_context) {}
 
 StreamSocket::StreamSocket(IOContext &io_context, SocketFd fd) : ::rm::StreamSocket(fd), _ctx(io_context) {}
 
@@ -1496,7 +1532,7 @@ bool StreamSocket::SocketWriteAwaiter::await_resume() {
     return n == static_cast<ssize_t>(_data.size());
 }
 
-Acceptor::Acceptor(IOContext &io_context, const Endpoint &endpoint) : ::rm::Acceptor(endpoint, true), _ctx(io_context) {}
+Acceptor::Acceptor(IOContext &io_context, const Endpoint &endpoint) : ::rm::Acceptor(endpoint, false), _ctx(io_context) {}
 
 StreamSocket Acceptor::AcceptAwaiter::await_resume() noexcept {
     RMVL_DbgAssert(_fd != INVALID_FD);
@@ -1505,12 +1541,40 @@ StreamSocket Acceptor::AcceptAwaiter::await_resume() noexcept {
     return StreamSocket(_ctx, sfd);
 }
 
-Connector::Connector(IOContext &io_context, const Endpoint &endpoint, std::string_view url) : ::rm::Connector(endpoint, url, true), _ctx(io_context) {}
+Connector::Connector(IOContext &io_context, const Endpoint &endpoint, std::string_view url) : ::rm::Connector(endpoint, url, false), _ctx(io_context) {}
+
+bool Connector::ConnectAwaiter::await_suspend(std::coroutine_handle<> handle) {
+    RMVL_DbgAssert(_fd != INVALID_FD);
+    sockaddr_storage remote{};
+    socklen_t addr_len{};
+    if (!fill_sockaddr(_endpoint, _data, remote, addr_len))
+        RMVL_Error(RMVL_StsBadArg, "Invalid socket address");
+
+    if (::connect(_fd, reinterpret_cast<sockaddr *>(&remote), addr_len) == 0)
+        return false;
+    if (errno != EINPROGRESS)
+        RMVL_Error_(RMVL_StsError, "Connection failed, error code: %d", error_code());
+
+    epoll_event ev{};
+    ev.events = EPOLLOUT;
+    ev.data.ptr = handle.address();
+    if (epoll_ctl(_aioh, EPOLL_CTL_ADD, _fd, &ev) == -1)
+        RMVL_Error_(RMVL_StsBadArg, "Failed to add fd to epoll: %s", strerror(errno));
+    return true;
+}
 
 StreamSocket Connector::ConnectAwaiter::await_resume() noexcept {
     RMVL_DbgAssert(_fd != INVALID_FD);
     epoll_ctl(_aioh, EPOLL_CTL_DEL, _fd, nullptr);
-    int sfd = fdconnect(_fd, _endpoint, _data);
+    int error{};
+    socklen_t len = sizeof(error);
+    if (getsockopt(_fd, SOL_SOCKET, SO_ERROR, &error, &len) == -1 || error != 0) {
+        if (error != 0)
+            errno = error;
+        WARNING_("Connection failed, error code: %d", error_code());
+        return StreamSocket(_ctx, INVALID_SOCKET_FD);
+    }
+    int sfd = std::exchange(_owner_fd, INVALID_SOCKET_FD);
     return StreamSocket(_ctx, sfd);
 }
 

--- a/modules/io/src/util.cpp
+++ b/modules/io/src/util.cpp
@@ -10,6 +10,7 @@
  */
 
 #include <algorithm>
+#include <cctype>
 #include <fstream>
 #include <sstream>
 
@@ -17,6 +18,20 @@
 #include "rmvl/io/util.hpp"
 
 namespace rm {
+
+static bool readFloatToken(std::istream &is, float &value) noexcept {
+    std::string token;
+    if (!(is >> token))
+        return false;
+    while (!token.empty() && (token.back() == ',' || std::isspace(static_cast<unsigned char>(token.back()))))
+        token.pop_back();
+    try {
+        value = std::stof(token);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
 
 void ImuData::write(std::ostream &os, const ImuData &data) noexcept {
     os << data.translation.x << ", " << data.translation.y << ", " << data.translation.z << ", "
@@ -26,15 +41,11 @@ void ImuData::write(std::ostream &os, const ImuData &data) noexcept {
 }
 
 void ImuData::read(std::istream &is, ImuData &data) noexcept {
-    std::string tstr[6];
-    std::for_each(tstr, tstr + 6, [&is](std::string &s) { is >> s; });
-    size_t t_idx = 0;
-    reflect::for_each(data.translation, [&](auto &&val) { val = std::stof(tstr[t_idx++]); });
-
-    std::string rstr[6];
-    std::for_each(rstr, rstr + 6, [&is](std::string &s) { is >> s; });
-    size_t r_idx = 0;
-    reflect::for_each(data.rotation, [&](auto &&val) { val = std::stof(rstr[r_idx++]); });
+    bool ok = true;
+    reflect::for_each(data.translation, [&](auto &&val) { ok = ok && readFloatToken(is, val); });
+    reflect::for_each(data.rotation, [&](auto &&val) { ok = ok && readFloatToken(is, val); });
+    if (!ok)
+        is.setstate(std::ios::failbit);
 }
 
 void ImuData::write(std::string_view output_file, const std::vector<ImuData> &datas) noexcept {
@@ -51,10 +62,11 @@ std::vector<ImuData> ImuData::read(std::string_view input_file) noexcept {
         return {};
     std::vector<ImuData> datas;
     datas.reserve(1000);
-    while (!ifs.eof()) {
+    while (ifs) {
         ImuData d;
         read(ifs, d);
-        datas.push_back(d);
+        if (ifs)
+            datas.push_back(d);
     }
     ifs.close();
     return datas;
@@ -62,6 +74,8 @@ std::vector<ImuData> ImuData::read(std::string_view input_file) noexcept {
 
 void writeCorners(std::ostream &out, const std::vector<std::vector<std::array<float, 2>>> &corners) {
     std::for_each(corners.begin(), corners.end(), [&out](const auto &corner) {
+        if (corner.empty())
+            return;
         std::for_each(corner.begin(), corner.end() - 1, [&out](const auto &p) {
             out << p[0] << ", " << p[1] << ", ";
         });
@@ -77,12 +91,14 @@ void readCorners(std::istream &in, std::vector<std::vector<std::array<float, 2>>
             break;
         std::vector<std::array<float, 2>> corner;
         std::istringstream iss(line);
-        while (!iss.eof()) {
-            std::string point[2];
-            iss >> point[0] >> point[1];
-            corner.push_back({std::stof(point[0]), std::stof(point[1])});
+        while (iss) {
+            float point[2]{};
+            if (!readFloatToken(iss, point[0]) || !readFloatToken(iss, point[1]))
+                break;
+            corner.push_back({point[0], point[1]});
         }
-        corners.emplace_back(std::move(corner));
+        if (!corner.empty())
+            corners.emplace_back(std::move(corner));
     }
 }
 


### PR DESCRIPTION
### Pull Request 合并请求准备清单

详情参见[此处](https://github.com/cv-rmvl/rmvl/wiki/How_to_contribute#3-making-a-good-pull-request)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

1. 修复 SerialPort、Socket、IPC、SHM 等资源类的移动语义，避免 fd/handle 泄漏、重复关闭和重复 unlink
2. 修复 Connector 返回 socket 后所有权未转移导致 fd 被提前关闭的问题
3. 修复 Linux async socket 的非阻塞连接流程，改为 connect + EPOLLOUT + SO_ERROR 检查
4. 修复 Task<void> 异常传播和 IOContext 顶层任务异常检查
5. 修复多缓冲区写入长度判断、URL 解析和 util 数据解析的边界问题